### PR TITLE
Document unattended installation of SAP products, including reference to SUSE Manager

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -245,6 +245,8 @@
 <!ENTITY s4h            "&sap; S/4HANA">
 <!ENTITY s4ha           "&sap; S/4HANA Application Server">
 <!ENTITY s4hd           "&sap; S/4HANA Database Server">
+<!ENTITY trex           "&sap; TREX">
+
 <!ENTITY instmaster     "Installation Master">
 <!-- Almost always using the plural here: one dir to copy from can contain
      multiple "CDs": -->

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -15,6 +15,7 @@
 <!ENTITY novell         "Novell">
 <!ENTITY suseconfig     "SuSEconfig">
 <!ENTITY suselinux      "&suse; Linux">
+<!ENTITY susemanager    "&suse; Manager">
 <!ENTITY suseonsite     "&suse; Studio Onsite">
 <!ENTITY suseonsitereg  "&suseonsite;&reg;">
 <!-- suse studio service as different from the Onsite product -->
@@ -34,6 +35,7 @@
 <!ENTITY docaddress     "<link xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='https://www.suse.com/documentation/sles-12/'/>">
 <!ENTITY ha-docaddress  "<link xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='https://www.suse.com/documentation/sle-ha-12/'/>">
 <!ENTITY sapnoteaddress "https://launchpad.support.sap.com/#/notes/">
+<!ENTITY suma-docaddress "<link xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='https://www.suse.com/documentation/suse-manager-3/'/>">
 <!ENTITY reslibrary     "<link xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='https://www.suse.com/products/sles-for-sap/resource-library/'/>">
 
 <!ENTITY deploy         "<emphasis xmlns='http://docbook.org/ns/docbook'>Deployment Guide</emphasis>">

--- a/xml/s4s_autoyast.xml
+++ b/xml/s4s_autoyast.xml
@@ -31,4 +31,9 @@
   <xref linkend="sec.s4s.partition"/>.
  </para>
 
+ <para>
+   If you plan to deploy &sles4sap; from a &susemanager; server, refer to
+   <citetitle>&susemanager; <quote>Reference Manual</quote>, <quote>Systems</quote>, <quote>Autoinstallation</quote></citetitle> and <citetitle>&susemanager; <quote>Advanced Topics</quote>, Chapter <quote>Minimalist &ay; Profile for Automated Installations and Useful Enhancements</quote></citetitle> (&suma-docaddress;).
+ </para>
+ 
 </sect1>

--- a/xml/s4s_installation_sap.xml
+++ b/xml/s4s_installation_sap.xml
@@ -966,7 +966,7 @@ SAP-NetWeaver-740-SR2-Installation-Export-CD-3-3</screen>
 
   <para>The &sapwiz; can be used from &ay; in order to automate the installation of &sap; Applications.</para>
 
-  <para>The following &ay; snippet shows how &hana; installation can be automated:</para>
+  <para>The following &ay; snippet shows how a &hana; or &trex;  installation can be automated:</para>
 
   <screen><![CDATA[
    <sap-inst>
@@ -990,6 +990,17 @@ SAP-NetWeaver-740-SR2-Installation-Export-CD-3-3</screen>
      </products>
    </sap-inst>]]></screen>
 
+  <important>
+   <itemizedlist>
+    <listitem>
+     <para>The <tag>sapMDC</tag> element is only applicable to &hana;</para>
+    </listitem>
+    <listitem>
+      <para>The <tag>sapVirtHostname</tag> element must be specified for distributed or highly available installations.</para>
+    </listitem>
+   </itemizedlist>
+  </important>
+  
   <para>
     For a full &hana; example, including partitioning, see <filename>/usr/share/doc/packages/sap-installation-wizard/hana-autoyast.xml</filename>.
   </para>

--- a/xml/s4s_installation_sap.xml
+++ b/xml/s4s_installation_sap.xml
@@ -512,7 +512,7 @@
       <listitem>
        <para>
         Do not copy additional &instmedia;. Choose this option
-        if you do not need additional &instmedia; or if you want to install
+        if you do not need additional &instmedia; or to install
         additional &instmedia; directly from their source, for example
         CDs/DVDs or flash disks.
        </para>
@@ -624,7 +624,7 @@
        <para>
         Allows changing the various system properties such as the &sap; system ID,
         database ID, instance number or host name. This is useful, for example,
-        when you want to install the same product in a very similar
+        to install the same product in a very similar
         configuration on different systems.
        </para>
        <!--
@@ -964,101 +964,160 @@ SAP-NetWeaver-740-SR2-Installation-Export-CD-3-3</screen>
  <sect1 xml:id="sec.s4s.install.sap.autoyast">
   <title>Automated Installation of &sap; Applications with &ay;</title>
 
-  <para>The &sapwiz; can be used from &ay; in order to automate the installation of &sap; Applications.</para>
-
-  <para>The following &ay; snippet shows how a &hana; or &trex;  installation can be automated:</para>
-
-  <screen language="xml"><![CDATA[
-   <sap-inst>
-     <products config:type="list">
-       <product>
-         <media config:type="list">
-           <medium>
-             <url>nfs://server/path1</url>
-             <type>sap</type>
-           </medium>
-           <medium>
-             <url>nfs://server/path3</url>
-             <type>supplement</type>
-           </medium>
-         </media>
-         <sapMasterPW>PASSWORD</sapMasterPW>
-         <sid>HA1</sid>
-         <sapInstNr>00</sapInstNr>
-         <sapMDC>no</sapMDC>
-       </product>
-     </products>
-   </sap-inst>]]></screen>
-
-  <important>
-   <itemizedlist>
-    <listitem>
-     <para>The <tag>sapMDC</tag> element is only applicable to &hana;</para>
-    </listitem>
-    <listitem>
-      <para>The <tag>sapVirtHostname</tag> element must be specified for distributed or highly available installations.</para>
-    </listitem>
-   </itemizedlist>
-  </important>
-  
   <para>
-    For a full &hana; example, including partitioning, see <filename>/usr/share/doc/packages/sap-installation-wizard/hana-autoyast.xml</filename>.
+   The &sapwiz; can be used from &ay; to automate the installation of &sap;
+   Applications.
   </para>
 
-  <para>For &netweaver;, the following snippet shows how the installation can be automated:</para>
-  <screen language="xml"><![CDATA[
-   <sap-inst>
-     <products config:type="list">
-       <product>
-         <media config:type="list">
-           <medium>
-             <url>nfs://server/path1</url>
-             <type>sap</type>
-           </medium>
-           <medium>
-             <url>nfs://server/path2</url>
-             <type>sap</type>
-           </medium>
-           <medium>
-             <url>nfs://server/path3</url>
-             <type>supplement</type>
-           </medium>
-         </media>
-         <productID>NW_ABAP_ASCS:NW750.ADA.ABAP</productID>
-         <iniFile>
-           <![CDATA[
-                     ###########################################################################################################################################################################
-                     #                                                                                                                                                                         #
-                     # Installation service 'SAP NetWeaver 7.5 > MaxDB > SAP Systems > Application Server ABAP > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:NW750.ADA.ABAP' #
-                     #                                                                                                                                                                         #
-                     ###########################################################################################################################################################################
+  <sect2 xml:id="sec.s4s.install.sap.autoyast.hana">
+   <title>&hana; Installation</title>
+   <para>
+    The following &ay; snippet shows how an &hana; or &trex; installation can
+    be automated:
+   </para>
 
-#USED PARAMETERS ##masterPwd## ##sid## ##kernel## ##ascsVirtualHostname## ##instanceNumber## ##scsVirtualHostname##
+   <screen language="xml"><![CDATA[
+<sap-inst>
+  <products config:type="list">
+    <product>
+      <media config:type="list">
+        <medium>
+          <url>nfs://server/path1</url>
+          <type>sap</type>
+        </medium>
+        <medium>
+          <url>nfs://server/path3</url>
+          <type>supplement</type>
+        </medium>
+      </media>
+      <sapMasterPW>]]><replaceable>PASSWORD</replaceable><![CDATA[</sapMasterPW>
+      <sid>]]><replaceable>SID</replaceable><![CDATA[</sid>
+      <sapInstNr>]]><replaceable>INSTANCE_NUMBER</replaceable><![CDATA[</sapInstNr>
+      <sapMDC>no</sapMDC>
+    </product>
+  </products>
+</sap-inst>
+   ]]></screen>
 
-# Password for the Diagnostics Agent specific <dasid>adm user. Provided value may be encoded.
+   <itemizedlist>
+    <listitem>
+     <para>
+      The <tag>sapMDC</tag> element is only applicable to &hana;.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The <tag>sapVirtHostname</tag> element must be specified for
+      distributed or highly available installations.
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+     For a full &hana; example, including partitioning, see
+     <filename>/usr/share/doc/packages/sap-installation-wizard/hana-autoyast.xml</filename>.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec.s4s.install.sap.autoyast.netweaver">
+   <title>&nw; Installation</title>
+   <para>
+    For &netweaver;, the following example shows how the installation can be
+    automated. Specifically, this example is tailored to installing ASCS
+    Instance of an &nw; 7.5 ABAP Server distributed system with MaxDB
+    (product ID <literal>NW_ABAP_ASCS:NW750.ADA.ABAP</literal>). When
+    installing other products based on &nw;, not all of the following
+    variables may be necessary or these variables might need to be replaced
+    by others:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      The master password for the &nw; instance:
+      <replaceable>MASTER_PASSWORD</replaceable>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The &sap; Identifier (SID): <replaceable>SID</replaceable>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The &sap; kernel: <replaceable>KERNEL</replaceable>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The &sap; instance number: <replaceable>INSTANCE_NUMBER</replaceable>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The ASCS virtual host name:
+      <replaceable>ASCS_VIRTUAL_HOSTNAME</replaceable>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The SCS virtual host name: <replaceable>SCS_VIRTUAL_HOSTNAME</replaceable>
+     </para>
+    </listitem>
+   </itemizedlist>
+
+   <screen language="xml"><![CDATA[
+<sap-inst>
+  <products config:type="list">
+    <product>
+      <media config:type="list">
+        <medium>
+          <url>]]><replaceable>nfs://SERVER/PATH1</replaceable><![CDATA[</url>
+          <type>sap</type>
+        </medium>
+        <medium>
+          <url>]]><replaceable>nfs://SERVER/PATH2</replaceable><![CDATA[</url>
+          <type>sap</type>
+        </medium>
+        <medium>
+          <url>]]><replaceable>nfs://SERVER/PATH3</replaceable><![CDATA[</url>
+          <type>supplement</type>
+        </medium>
+      </media>
+      <productID>NW_ABAP_ASCS:NW750.ADA.ABAP</productID>
+      <iniFile>
+        <![CDATA[
+# Password for the Diagnostics Agent specific <dasid>adm user. Provided value
+# may be encoded.
 DiagnosticsAgent.dasidAdmPassword =
 
 # Windows domain in which the Diagnostics Agent users must be created.
 # The property is Microsoft Windows only. This is an optional property.
 DiagnosticsAgent.domain =
 
-# Password for the Diagnostics Agent specific SAPService<DASID> user. Provided value may be encoded.
+# Password for the Diagnostics Agent specific SAPService<DASID> user.
+# Provided value may be encoded.
 # The property is Microsoft Windows only.
 DiagnosticsAgent.sapServiceDASIDPassword =
 
-NW_GetMasterPassword.masterPwd = ##masterPwd##
+NW_GetMasterPassword.masterPwd = ]]><replaceable>MASTER_PASSWORD</replaceable><![CDATA[
 
-# Human readable form of the Default Login language - used for instant in the preselection in SAPGUI. This Parameter is potentialy asked in addition in the dialog that also asks for the SID. It is not asked in all this dialogs, but only in systems that have ( potentialy beside others ) an ABAP stack. It is ask for installation but not for system copy. It is asked in those installations, that perform the ABAP load. That could be the Database Load installation in case of a distributed szenario, or in the Standard Installer, that is not distributed at all. This Parameter is saved in the Default Profile. It is has no influence on Language settings in a Java Stack. Valid names are stored in a table of the subcomponent NW_languagesInLoadChecks. The available languages must be declaired in the LANGUAGES_IN_LOAD parameter of the product.xml . In this file the one character representation of the languages is uses. Check the same table in the subcomponent mentioned above.
+# Human readable form of the Default Login language - valid names are stored
+# in a table of the subcomponent NW_languagesInLoadChecks. Used when freshly
+# installing an ABAP stack for the machine that performs an ABAP load (in the
+# case of a distributed system, that is the database, otherwise it is used by
+# the normal installer). The available languages must be declared in the
+# LANGUAGES_IN_LOAD parameter of the product.xml . In this file, the one
+# character representation of the languages is used. Check the same table in
+# the subcomponent mentioned above.
 NW_GetSidNoProfiles.SAP_GUI_DEFAULT_LANGUAGE =
 
-# The drive to use (windows only)
+# The drive to use (Windows only)
 NW_GetSidNoProfiles.sapdrive =
 
-# The /sapmnt path (unix only)
+# The /sapmnt path (Unix only)
 NW_GetSidNoProfiles.sapmnt = /sapmnt
 
 # The SAP System ID of the system to install
-NW_GetSidNoProfiles.sid = ##sid##
+NW_GetSidNoProfiles.sid = ]]><replaceable>SID</replaceable><![CDATA[
 
 # Will this system be unicode system?
 NW_GetSidNoProfiles.unicode = true
@@ -1067,15 +1126,15 @@ NW_SAPCrypto.SAPCryptoFile = /data/SAP_CDs/745-UKERNEL-SAP-Unicode-Kernel-745/DB
 
 NW_SCS_Instance.ascsInstanceNumber =
 
-NW_SCS_Instance.ascsVirtualHostname = ##ascsVirtualHostname##
+NW_SCS_Instance.ascsVirtualHostname = ]]><replaceable>ASCS_VIRTUAL_HOSTNAME</replaceable><![CDATA[
 
-NW_SCS_Instance.instanceNumber = ##instanceNumber##
+NW_SCS_Instance.instanceNumber = ]]><replaceable>INSTANCE_NUMBER</replaceable><![CDATA[
 
 NW_SCS_Instance.scsInstanceNumber =
 
 NW_SCS_Instance.scsMSPort =
 
-NW_SCS_Instance.scsVirtualHostname = ##scsVirtualHostname##
+NW_SCS_Instance.scsVirtualHostname = ]]><replaceable>SCS_VIRTUAL_HOSTNAME</replaceable><![CDATA[
 
 NW_System.installSAPHostAgent = true
 
@@ -1099,13 +1158,15 @@ NW_getFQDN.FQDN =
 # Do we want to set the FQDN for the system?
 NW_getFQDN.setFQDN = false
 
-# The path to the jce policy archive to install into the java home directory if it is not already installed.
+# The path to the JCE policy archive to install into the Java home directory
+# if it is not already installed.
 NW_getJavaHome.jcePolicyArchive =
 
 hostAgent.domain =
 
-# Password for the SAP Host Agent specific sapadm user. Provided value may be encoded.
-hostAgent.sapAdmPassword = ##masterPwd##
+# Password for the SAP Host Agent specific sapadm user. Provided value may be
+# encoded.
+hostAgent.sapAdmPassword = ]]><replaceable>MASTER_PASSWORD</replaceable><![CDATA[
 
 nwUsers.sapDomain =
 
@@ -1113,10 +1174,12 @@ nwUsers.sapServiceSIDPassword =
 
 nwUsers.sidadmPassword =
             ]]]]><![CDATA[>
-</iniFile>
-</product>
-</products>
-</sap-inst>]]></screen>
+      </iniFile>
+    </product>
+  </products>
+</sap-inst>
+   ]]></screen>
+  </sect2>
  </sect1>
 
 </chapter>

--- a/xml/s4s_installation_sap.xml
+++ b/xml/s4s_installation_sap.xml
@@ -982,7 +982,7 @@ SAP-NetWeaver-740-SR2-Installation-Export-CD-3-3</screen>
              <type>supplement</type>
            </medium>
          </media>
-         <sapMasterPW>secret</sapMasterPW>
+         <sapMasterPW>PASSWORD</sapMasterPW>
          <sid>HA1</sid>
          <sapInstNr>00</sapInstNr>
          <sapMDC>no</sapMDC>

--- a/xml/s4s_installation_sap.xml
+++ b/xml/s4s_installation_sap.xml
@@ -961,4 +961,151 @@ SAP-NetWeaver-740-SR2-Installation-Export-CD-3-3</screen>
   <screen>&prompt.root;<command>yast2 sap_create_storage <replaceable>ABSOLUTE_PATH_TO_PARTITIONING_FILE</replaceable></command></screen>
  </sect1>
 
+ <sect1 xml:id="sec.s4s.install.sap.autoyast">
+  <title>Automated Installation of &sap; Applications with &ay;</title>
+
+  <para>The &sapwiz; can be used from &ay; in order to automate the installation of &sap; Applications.</para>
+
+  <para>The following &ay; snippet shows how &hana; installation can be automated:</para>
+
+  <screen><![CDATA[
+   <sap-inst>
+     <products config:type="list">
+       <product>
+         <media config:type="list">
+           <medium>
+             <url>nfs://server/path1</url>
+             <type>sap</type>
+           </medium>
+           <medium>
+             <url>nfs://server/path3</url>
+             <type>supplement</type>
+           </medium>
+         </media>
+         <sapMasterPW>secret</sapMasterPW>
+         <sid>HA1</sid>
+         <sapInstNr>00</sapInstNr>
+         <sapMDC>no</sapMDC>
+       </product>
+     </products>
+   </sap-inst>]]></screen>
+
+  <para>
+    For a full &hana; example, including partitioning, see <filename>/usr/share/doc/packages/sap-installation-wizard/hana-autoyast.xml</filename>.
+  </para>
+
+  <para>For &netweaver;, the following snippet shows how the installation can be automated:</para>
+  <screen><![CDATA[
+   <sap-inst>
+     <products config:type="list">
+       <product>
+         <media config:type="list">
+           <medium>
+             <url>nfs://server/path1</url>
+             <type>sap</type>
+           </medium>
+           <medium>
+             <url>nfs://server/path2</url>
+             <type>sap</type>
+           </medium>
+           <medium>
+             <url>nfs://server/path3</url>
+             <type>supplement</type>
+           </medium>
+         </media>
+         <productID>NW_ABAP_ASCS:NW750.ADA.ABAP</productID>
+         <iniFile>
+           <![CDATA[
+                     ###########################################################################################################################################################################
+                     #                                                                                                                                                                         #
+                     # Installation service 'SAP NetWeaver 7.5 > MaxDB > SAP Systems > Application Server ABAP > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:NW750.ADA.ABAP' #
+                     #                                                                                                                                                                         #
+                     ###########################################################################################################################################################################
+
+#USED PARAMETERS ##masterPwd## ##sid## ##kernel## ##ascsVirtualHostname## ##instanceNumber## ##scsVirtualHostname##
+
+# Password for the Diagnostics Agent specific <dasid>adm user. Provided value may be encoded.
+DiagnosticsAgent.dasidAdmPassword =
+
+# Windows domain in which the Diagnostics Agent users must be created.
+# The property is Microsoft Windows only. This is an optional property.
+DiagnosticsAgent.domain =
+
+# Password for the Diagnostics Agent specific SAPService<DASID> user. Provided value may be encoded.
+# The property is Microsoft Windows only.
+DiagnosticsAgent.sapServiceDASIDPassword =
+
+NW_GetMasterPassword.masterPwd = ##masterPwd##
+
+# Human readable form of the Default Login language - used for instant in the preselection in SAPGUI. This Parameter is potentialy asked in addition in the dialog that also asks for the SID. It is not asked in all this dialogs, but only in systems that have ( potentialy beside others ) an ABAP stack. It is ask for installation but not for system copy. It is asked in those installations, that perform the ABAP load. That could be the Database Load installation in case of a distributed szenario, or in the Standard Installer, that is not distributed at all. This Parameter is saved in the Default Profile. It is has no influence on Language settings in a Java Stack. Valid names are stored in a table of the subcomponent NW_languagesInLoadChecks. The available languages must be declaired in the LANGUAGES_IN_LOAD parameter of the product.xml . In this file the one character representation of the languages is uses. Check the same table in the subcomponent mentioned above.
+NW_GetSidNoProfiles.SAP_GUI_DEFAULT_LANGUAGE =
+
+# The drive to use (windows only)
+NW_GetSidNoProfiles.sapdrive =
+
+# The /sapmnt path (unix only)
+NW_GetSidNoProfiles.sapmnt = /sapmnt
+
+# The SAP System ID of the system to install
+NW_GetSidNoProfiles.sid = ##sid##
+
+# Will this system be unicode system?
+NW_GetSidNoProfiles.unicode = true
+
+NW_SAPCrypto.SAPCryptoFile = /data/SAP_CDs/745-UKERNEL-SAP-Unicode-Kernel-745/DBINDEP/SAPEXE.SAR
+
+NW_SCS_Instance.ascsInstanceNumber =
+
+NW_SCS_Instance.ascsVirtualHostname = ##ascsVirtualHostname##
+
+NW_SCS_Instance.instanceNumber = ##instanceNumber##
+
+NW_SCS_Instance.scsInstanceNumber =
+
+NW_SCS_Instance.scsMSPort =
+
+NW_SCS_Instance.scsVirtualHostname = ##scsVirtualHostname##
+
+NW_System.installSAPHostAgent = true
+
+NW_Unpack.igsExeSar =
+
+NW_Unpack.igsHelperSar =
+
+NW_Unpack.sapExeDbSar =
+
+NW_Unpack.sapExeSar =
+
+NW_Unpack.sapJvmSar =
+
+NW_Unpack.xs2Sar =
+
+NW_adaptProfile.templateFiles =
+
+# The FQDN of the system.
+NW_getFQDN.FQDN =
+
+# Do we want to set the FQDN for the system?
+NW_getFQDN.setFQDN = false
+
+# The path to the jce policy archive to install into the java home directory if it is not already installed.
+NW_getJavaHome.jcePolicyArchive =
+
+hostAgent.domain =
+
+# Password for the SAP Host Agent specific sapadm user. Provided value may be encoded.
+hostAgent.sapAdmPassword = ##masterPwd##
+
+nwUsers.sapDomain =
+
+nwUsers.sapServiceSIDPassword =
+
+nwUsers.sidadmPassword =
+            ]]]]><![CDATA[>
+</iniFile>
+</product>
+</products>
+</sap-inst>]]></screen>
+ </sect1>
+
 </chapter>

--- a/xml/s4s_installation_sap.xml
+++ b/xml/s4s_installation_sap.xml
@@ -968,7 +968,7 @@ SAP-NetWeaver-740-SR2-Installation-Export-CD-3-3</screen>
 
   <para>The following &ay; snippet shows how a &hana; or &trex;  installation can be automated:</para>
 
-  <screen><![CDATA[
+  <screen language="xml"><![CDATA[
    <sap-inst>
      <products config:type="list">
        <product>
@@ -1006,7 +1006,7 @@ SAP-NetWeaver-740-SR2-Installation-Export-CD-3-3</screen>
   </para>
 
   <para>For &netweaver;, the following snippet shows how the installation can be automated:</para>
-  <screen><![CDATA[
+  <screen language="xml"><![CDATA[
    <sap-inst>
      <products config:type="list">
        <product>


### PR DESCRIPTION
This PR provides:

* Mention SUSE Manager in the unattended installation of the OS section, pointing to the right chapters
* Adds a section about installing SAP products with automated installation
* Provides example snippets for the SAP product section
* Makes reference to a full HANA example now included in the sap-installation wizard package.