### PR TITLE
Fix bsc#1154579: Improve supported POWER architectures

### DIFF
--- a/xml/s4s_planning.xml
+++ b/xml/s4s_planning.xml
@@ -23,18 +23,17 @@
   </para>
   <variablelist>
    <varlistentry>
-    <term>CPU</term>
+    <term>Supported CPU</term>
     <listitem>
      <para>
       &x86-64;
      </para>
      <para>
-      IBM &power; servers with PowerKVM compatibility
+      IBM &power;&nbsp;8 (with PowerVM)
      </para>
-     <remark>
-      FIXME: POWER 8 and 9? Presumably also needs fixing in SLES Deploy.
-      - sknorr, 2017-09-07
-     </remark>
+     <para>
+      IBM &power;&nbsp;9 (with PowerVM)
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>


### PR DESCRIPTION
According to the bug, it applies to:

* [ ] SLES4SAP 12 SP4
* [ ] SLES4SAP 15 GA
* [ ] SLES4SAP 15 SP1
* [ ] SLES4SAP 15 SP2 (=master as of 2019/10/29)