### PR TITLE
Convert SLES for SAP11 SP4 to DocBook5

### DIFF
--- a/DC-SLES4SAP-guide
+++ b/DC-SLES4SAP-guide
@@ -13,7 +13,7 @@ ROOTID=""
 PROFOS="sled;sles"
 PROFARCH="ipf;x86;amd64;em64t;power;s390;zseries"
 
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 

--- a/xml/MAIN-SLES4SAP-guide.xml
+++ b/xml/MAIN-SLES4SAP-guide.xml
@@ -1,32 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-                 type="text/xml" 
-                 title="Profiling step"?>
-<!DOCTYPE book PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN"
-                      "novdocx.dtd"
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE book
 [
-  <!ENTITY % NOVDOC.DEACTIVATE.IDREF "IGNORE">
-  <!ENTITY % entities SYSTEM "entity-decl.ent">
-  %entities;
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<book lang="en" id="book-s4s">
-<?dbhtml filename="index.html"?>
- <bookinfo>
-  <title>The Guide</title>
-   <productname>&productname;</productname>
-   <productnumber>&productnumber;</productnumber>
-  <date>
+
+
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:lang="en" xml:id="book-s4s"><?dbhtml filename="index.html"?><title>The Guide</title><info><productname>&productname;</productname><productnumber>&productnumber;</productnumber><date>
    <?dbtimestamp format="B d, Y"?>
-  </date>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_copyright_gfdl.xml"/>
- </bookinfo>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_overview.xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_about.xml"/>
+  </date><xi:include href="common_copyright_gfdl.xml" parse="xml"/></info>
+
+ 
+ <xi:include href="s4s_overview.xml" parse="xml"/>
+ <xi:include href="s4s_about.xml" parse="xml"/>
  <!-- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_qinstall.xml"/> -->
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_installation.xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_partitioning.xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_install_network.xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_components.xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_appendix_cryptoaddon.xml" />
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_appendix_docupdates.xml" />
+ <xi:include href="s4s_installation.xml" parse="xml"/>
+ <xi:include href="s4s_partitioning.xml" parse="xml"/>
+ <xi:include href="s4s_install_network.xml" parse="xml"/>
+ <xi:include href="s4s_components.xml" parse="xml"/>
+ <xi:include href="s4s_appendix_cryptoaddon.xml" parse="xml"/>
+ <xi:include href="s4s_appendix_docupdates.xml" parse="xml"/>
 </book>

--- a/xml/common_copyright_gfdl.xml
+++ b/xml/common_copyright_gfdl.xml
@@ -1,17 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE legalnotice PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd"
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE legalnotice
 [
-  <!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-  <!ENTITY % entities SYSTEM "entity-decl.ent">
-  %entities;
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
+
+
 <!--
      Please keep this document neatly formatted, because a text version
      for LICENSE.txt is created form this source. That means only the
      xml tags will be stripped, the rest of the formatting will appear
      in the txt file as is.
 -->
-<legalnotice>
+<legalnotice xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink">
  <para>
   Copyright &copy; <?dbtimestamp format="Y"?>
   SUSE LLC and contributors. All rights reserved.
@@ -24,8 +29,7 @@
   section entitled <quote>GNU Free Documentation License</quote>.
  </para>
  <para>
-  For SUSE trademarks, see Trademark and Service Mark list <ulink
-  url="http://www.suse.com/company/legal/"/>.  Linux* is a registered
+  For SUSE trademarks, see Trademark and Service Mark list <link version="5.1" xlink:href="http://www.suse.com/company/legal/"/>.  Linux* is a registered
   trademark of Linus Torvalds. All other third party trademarks are the
   property of their respective owners. A trademark symbol (&reg;,
   &trade; etc.) denotes a SUSE trademark; an asterisk (*) denotes a

--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -1,12 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd"
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1
 [
-  <!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-  <!ENTITY % entities SYSTEM "entity-decl.ent">
-  %entities;
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
+
+
 <!--taroth 080104: included several times, therefore no ID here, all products-->
-<sect1>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1">
  <title>Feedback</title>
 
  <para>
@@ -19,7 +24,7 @@
    <listitem>
     <para>
      To report bugs for a product component, or to submit enhancement
-     requests, please use <ulink url="https://bugzilla.novell.com/"/>. For
+     requests, please use <link xlink:href="https://bugzilla.novell.com/"/>. For
      documentation bugs, submit a bug report for the component
      <guimenu>Documentation</guimenu> of the respective product.
     </para>
@@ -27,15 +32,15 @@
      If you are new to Bugzilla, you might find the following articles
      helpful:
     </para>
-    <itemizedlist>
+    <itemizedlist mark="bullet" spacing="normal">
      <listitem>
       <para>
-       <ulink url="http://en.opensuse.org/openSUSE:Submitting_bug_reports"/>
+       <link xlink:href="http://en.opensuse.org/openSUSE:Submitting_bug_reports"/>
       </para>
      </listitem>
      <listitem>
       <para>
-       <ulink url="http://en.opensuse.org/openSUSE:Bug_reporting_FAQ"/>
+       <link xlink:href="http://en.opensuse.org/openSUSE:Bug_reporting_FAQ"/>
       </para>
      </listitem>
     </itemizedlist>
@@ -46,11 +51,11 @@
    <listitem>
     <para>
      For services and support options available for your product, refer to
-     <ulink url="http://www.suse.com/support/"></ulink>.
+     <link xlink:href="http://www.suse.com/support/"/>.
     </para>
     <para>
      To report bugs for a product component, log into the &ncc; from
-     <ulink url="http://www.suse.com/support/"/> and select <menuchoice>
+     <link xlink:href="http://www.suse.com/support/"/> and select <menuchoice>
      <guimenu>My Support</guimenu> <guimenu>Service Request</guimenu>
      </menuchoice>.
     </para>
@@ -63,7 +68,7 @@
      We want to hear your comments about and suggestions for this manual and the
      other documentation included with this product. Use the User Comments
      feature at the bottom of each page in the online documentation or go to
-     <ulink url="http://www.suse.com/documentation/feedback.html"/> and
+     <link xlink:href="http://www.suse.com/documentation/feedback.html"/> and
      enter your comments there.
      <!--taroth 2012-01-25: this at least now redirects to the novell
           feedback page, see bnc#723015-->
@@ -83,4 +88,4 @@
   </listitem>
    </varlistentry>
  </variablelist>
-</sect1>
+</section>

--- a/xml/common_intro_typografie_i.xml
+++ b/xml/common_intro_typografie_i.xml
@@ -1,11 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd"
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1
 [
-  <!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-  <!ENTITY % entities SYSTEM "entity-decl.ent">
-  %entities;
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<sect1>
+
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1">
 <!-- No ID here! -->
 
  <title>Documentation Conventions</title>
@@ -14,7 +19,7 @@
   The following typographical conventions are used in this manual:
  </para>
 
- <itemizedlist>
+ <itemizedlist mark="bullet" spacing="normal">
   <listitem>
    <para>
     <filename>/etc/passwd</filename>: directory names and filenames
@@ -77,4 +82,4 @@
    </para>
   </listitem>
  </itemizedlist>
-</sect1>
+</section>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -31,7 +31,7 @@
 <!ENTITY exampleclientIIslip  "sl&exampleclientII;">
 <!ENTITY exampleclientIIuucp  "uu&exampleclientII;">
 
-<!ENTITY rootuser       '<systemitem class="username">root</systemitem>'>
+<!ENTITY rootuser       '<systemitem class="username" xmlns="http://docbook.org/ns/docbook">root</systemitem>'>
 <!ENTITY grub           "GRUB">
 
 <!-- lilo will become obsolete with code 11 -->
@@ -65,40 +65,46 @@
 <!--                    Books                                      -->
 <!-- ============================================================= -->
 
-<!ENTITY deploy         "<emphasis>Deployment Guide</emphasis>">
-<!ENTITY kdeuser        "<emphasis>KDE User Guide</emphasis>">
-<!ENTITY gnomeuser      "<emphasis>GNOME User Guide</emphasis>">
-<!ENTITY moblinuser     "<emphasis>Moblin User Guide</emphasis>">
-<!ENTITY instquick      "<emphasis>Installation Quick Start</emphasis>">
-<!ENTITY gnomequick     "<emphasis>GNOME Quick Start</emphasis>">
-<!ENTITY kdequick       "<emphasis>KDE Quick Start</emphasis>">
-<!ENTITY moblinquick    "<emphasis>Moblin Quick Start</emphasis>">
-<!ENTITY oofficequick   "<emphasis>LibreOffice.org Quick Start</emphasis>">
-<!ENTITY apps           "<emphasis>Application Guide</emphasis>">
-<!ENTITY admin          "<emphasis>Administration Guide</emphasis>">
-<!ENTITY reference      "<emphasis>Reference</emphasis>">
-<!ENTITY startup       	"<emphasis>Start-Up</emphasis>">
-<!ENTITY aaadmin        "<emphasis>&aa; Administration Guide</emphasis>">
-<!ENTITY aaquick        "<emphasis>&aa; Quick Start</emphasis>">
-<!ENTITY lfl            "<emphasis>Lessons For Lizards</emphasis>">
-<!ENTITY storage        "<emphasis>Storage Administration Guide</emphasis>">
-<!ENTITY haguide        "<emphasis>High Availability Guide</emphasis>">
-<!ENTITY virtual        "<emphasis>Virtualization Guide</emphasis>">
-<!ENTITY xenguide       "<emphasis>Virtualization with &xen;</emphasis>">
-<!ENTITY kvmguide       "<emphasis>Virtualization with &kvm;</emphasis>">
-<!ENTITY auditguide     "<emphasis>The Linux Audit Framework</emphasis>">
-<!ENTITY auditquick     "<emphasis>Linux Audit Quick Start</emphasis>">
-<!ENTITY tuning         "<emphasis>System Analysis and Tuning Guide</emphasis>">
-<!ENTITY tuningsub      "<emphasis>Problem Detection, Resolution, and Optimization</emphasis>">
-<!ENTITY secguide       "<emphasis>Security Guide</emphasis>">
-<!ENTITY smtguide       "<emphasis>Subscription Management Tool Guide</emphasis>">
-<!ENTITY webyastconfguide       "<emphasis>WebYaST Configuration Guide</emphasis>">
-<!ENTITY studioadmin    "<emphasis>Administration Guide</emphasis>">
-<!ENTITY studioinstall  "<emphasis>Installation &amp; Deployment Guide</emphasis>">
+<!ENTITY deploy         "<emphasis xmlns='http://docbook.org/ns/docbook'>Deployment Guide</emphasis>">
+<!ENTITY kdeuser        "<emphasis xmlns='http://docbook.org/ns/docbook'>KDE User Guide</emphasis>">
+<!ENTITY gnomeuser      "<emphasis xmlns='http://docbook.org/ns/docbook'>GNOME User Guide</emphasis>">
+<!ENTITY moblinuser     "<emphasis xmlns='http://docbook.org/ns/docbook'>Moblin User Guide</emphasis>">
+<!ENTITY instquick      "<emphasis xmlns='http://docbook.org/ns/docbook'>Installation Quick Start</emphasis>">
+<!ENTITY gnomequick     "<emphasis xmlns='http://docbook.org/ns/docbook'>GNOME Quick Start</emphasis>">
+<!ENTITY kdequick       "<emphasis xmlns='http://docbook.org/ns/docbook'>KDE Quick Start</emphasis>">
+<!ENTITY moblinquick    "<emphasis xmlns='http://docbook.org/ns/docbook'>Moblin Quick Start</emphasis>">
+<!ENTITY oofficequick   "<emphasis xmlns='http://docbook.org/ns/docbook'>LibreOffice.org Quick Start</emphasis>">
+<!ENTITY apps           "<emphasis xmlns='http://docbook.org/ns/docbook'>Application Guide</emphasis>">
+<!ENTITY admin          "<emphasis xmlns='http://docbook.org/ns/docbook'>Administration Guide</emphasis>">
+<!ENTITY reference      "<emphasis xmlns='http://docbook.org/ns/docbook'>Reference</emphasis>">
+<!ENTITY startup       	"<emphasis xmlns='http://docbook.org/ns/docbook'>Start-Up</emphasis>">
+<!ENTITY aaadmin        "<emphasis xmlns='http://docbook.org/ns/docbook'>&aa; Administration Guide</emphasis>">
+<!ENTITY aaquick        "<emphasis xmlns='http://docbook.org/ns/docbook'>&aa; Quick Start</emphasis>">
+<!ENTITY lfl            "<emphasis xmlns='http://docbook.org/ns/docbook'>Lessons For Lizards</emphasis>">
+<!ENTITY storage        "<emphasis xmlns='http://docbook.org/ns/docbook'>Storage Administration Guide</emphasis>">
+<!ENTITY haguide        "<emphasis xmlns='http://docbook.org/ns/docbook'>High Availability Guide</emphasis>">
+<!ENTITY virtual        "<emphasis xmlns='http://docbook.org/ns/docbook'>Virtualization Guide</emphasis>">
+<!ENTITY xenguide       "<emphasis xmlns='http://docbook.org/ns/docbook'>Virtualization with &xen;</emphasis>">
+<!ENTITY kvmguide       "<emphasis xmlns='http://docbook.org/ns/docbook'>Virtualization with &kvm;</emphasis>">
+<!ENTITY auditguide     "<emphasis xmlns='http://docbook.org/ns/docbook'>The Linux Audit Framework</emphasis>">
+<!ENTITY auditquick     "<emphasis xmlns='http://docbook.org/ns/docbook'>Linux Audit Quick Start</emphasis>">
+<!ENTITY tuning         "<emphasis xmlns='http://docbook.org/ns/docbook'>System Analysis and Tuning Guide</emphasis>">
+<!ENTITY tuningsub      "<emphasis xmlns='http://docbook.org/ns/docbook'>Problem Detection, Resolution, and Optimization</emphasis>">
+<!ENTITY secguide       "<emphasis xmlns='http://docbook.org/ns/docbook'>Security Guide</emphasis>">
+<!ENTITY smtguide       "<emphasis xmlns='http://docbook.org/ns/docbook'>Subscription Management Tool Guide</emphasis>">
+<!ENTITY webyastconfguide       "<emphasis xmlns='http://docbook.org/ns/docbook'>WebYaST Configuration Guide</emphasis>">
+<!ENTITY studioadmin    "<emphasis xmlns='http://docbook.org/ns/docbook'>Administration Guide</emphasis>">
+<!ENTITY studioinstall  "<emphasis xmlns='http://docbook.org/ns/docbook'>Installation &amp; Deployment Guide</emphasis>">
 
-<!ENTITY docaddress     "<ulink url='https://www.suse.com/documentation/sles-12/'/>">
-<!ENTITY ha-docaddress  "<ulink url='https://www.suse.com/documentation/sle-ha-12/'/>">
-<!ENTITY reslibrary     "<ulink url='https://www.suse.com/products/sles-for-sap/resource-library/'/>">
+<!ENTITY docaddress     "<link xmlns='http://docbook.org/ns/docbook'
+                               xmlns:xlink='http://www.w3.org/1999/xlink'
+                               xlink:href='https://www.suse.com/documentation/sles-12/'/>">
+<!ENTITY ha-docaddress  "<link xmlns='http://docbook.org/ns/docbook'
+                               xmlns:xlink='http://www.w3.org/1999/xlink'
+                               xlink:href='https://www.suse.com/documentation/sle-ha-12/'/>">
+<!ENTITY reslibrary     "<link xmlns='http://docbook.org/ns/docbook'
+                               xmlns:xlink='http://www.w3.org/1999/xlink'
+                               xlink:href='https://www.suse.com/products/sles-for-sap/resource-library/'/>">
 
 
 <!-- ============================================================= -->
@@ -201,8 +207,8 @@
 <!ENTITY vmhost        "VM Host Server">
 <!ENTITY vmguest       "VM Guest">
 <!ENTITY dom0          "Domain0">
-<!ENTITY libvirt       '<systemitem class="library">libvirt</systemitem>'>
-<!ENTITY libvirtd      '<systemitem class="daemon">libvirtd</systemitem>'>
+<!ENTITY libvirt       '<systemitem class="library" xmlns="http://docbook.org/ns/docbook">libvirt</systemitem>'>
+<!ENTITY libvirtd      '<systemitem class="daemon" xmlns="http://docbook.org/ns/docbook">libvirtd</systemitem>'>
 <!ENTITY vmm           "Virtual Machine Manager">
 <!ENTITY pk            "PolicyKit">
 <!ENTITY ha            "High Availability">
@@ -245,21 +251,27 @@
 <!ENTITY nomad           "Nomad">
 <!ENTITY cpufreq         "CPUfreq">
 <!ENTITY qemu            "QEMU">
-<!ENTITY altf2           '<keycombo><keycap function="alt"/><keycap>F2</keycap></keycombo>'>
+<!ENTITY altf2           '<keycombo xmlns="http://docbook.org/ns/docbook"><keycap function="alt"/><keycap>F2</keycap></keycombo>'>
 
 
 <!ENTITY wypublic          "/srv/www/yast/public/">
-<!ENTITY mac               "<replaceable>MAC</replaceable>">
-<!ENTITY hwmac             "hwtype.<replaceable>MAC</replaceable>">
-<!ENTITY confmac           "config.<replaceable>MAC</replaceable>">
+<!ENTITY mac               "<replaceable xmlns='http://docbook.org/ns/docbook'>MAC</replaceable>">
+<!ENTITY hwmac             "hwtype.<replaceable xmlns='http://docbook.org/ns/docbook'>MAC</replaceable>">
+<!ENTITY confmac           "config.<replaceable xmlns='http://docbook.org/ns/docbook'>MAC</replaceable>">
 
 
 <!-- Additional Entities                                           -->
 <!ENTITY euro            "&#x20AC;">
 
-
 <!ENTITY % network-entities SYSTEM "network-decl.ent">
 %network-entities;
+
+<!ENTITY % sgml.features "IGNORE">
+<!ENTITY % xml.features "INCLUDE">
+<!ENTITY % dbcent PUBLIC "-//OASIS//ENTITIES DocBook Character
+  Entities V4.5//EN"
+  "http://www.oasis-open.org/docbook/xml/4.5/dbcentx.mod">
+  %dbcent;
 
 <!--                             End of file                       -->
 <!-- ............................................................. -->

--- a/xml/s4s_about.xml
+++ b/xml/s4s_about.xml
@@ -1,20 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<chapter id="s4s-about">
- <title>What is &sles4sap;?</title>
- <abstract>
+
+
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="s4s-about"><title>What is &sles4sap;?</title><info><abstract>
  <para>
   &sles4sapreg; is a bundle of software and services that addresses
   the specific needs of SAP users.  It is the only operating system that is
   optimized for all SAP software solutions.
  </para>
- </abstract>
+ </abstract></info>
+ 
+ 
 
-  <figure id="fig-s4s-picture">
+  <figure xml:id="fig-s4s-picture">
   <title>What is &sles4sap;?</title>
   <mediaobject>
    <imageobject role="fo">
@@ -27,13 +33,13 @@
  </figure>
 
 <!-- -=-=-=-=-=-=-=-=-=-=-=-=-=- cut here -=-=-=-=-=-=-=-=-=-=-=-=-=- -->
- <sect1 id="s4s-about-overview">
+ <section xml:id="s4s-about-overview">
   <title>Overview</title>
 
   <para>
   Target use cases include:
   </para>
-  <itemizedlist>
+  <itemizedlist mark="bullet" spacing="normal">
   <listitem>
    <para>
     Unix to Linux Migrations and Replatforming
@@ -52,9 +58,7 @@
   </itemizedlist>
 
   <para>
-   &sles4sap; consists of software components (see <xref
-   linkend="s4s-about-sw"/>) and service offerings (see <xref
-   linkend="s4s-about-services"/>).
+   &sles4sap; consists of software components (see <xref linkend="s4s-about-sw"/>) and service offerings (see <xref linkend="s4s-about-services"/>).
   </para>
 
   <!--
@@ -76,9 +80,9 @@ SUSE Linux Enterprise Server Priority Support for SAP Applications (optional)
    </listitem>
   </itemizedlist>
   -->
- </sect1>
+ </section>
 
- <sect1 id="s4s-about-sw">
+ <section xml:id="s4s-about-sw">
   <title>Software Components</title>
 
   <variablelist>
@@ -112,7 +116,7 @@ SUSE Linux Enterprise Server Priority Support for SAP Applications (optional)
      <para>
       This component consists of:
      </para>
-   <itemizedlist>
+   <itemizedlist mark="bullet" spacing="normal">
     <listitem>
      <para>
 Cluster manager
@@ -130,11 +134,9 @@ Resource agents, also for SAP
 </listitem>
    </itemizedlist>
 
-   <para>For more information about &sle; &hasi;, see the &haguide; (<ulink
-   url="http://www.suse.com/documentation/sle_ha/"/>)
+   <para>For more information about &sle; &hasi;, see the &haguide; (<link xlink:href="http://www.suse.com/documentation/sle_ha/"/>)
    and
-   the <emphasis>Best Practice Guides</emphasis> (<ulink
-   url="http://www.suse.com/products/sles-for-sap/resource-library/sap-best-practices.html"/>).</para>
+   the <emphasis>Best Practice Guides</emphasis> (<link xlink:href="http://www.suse.com/products/sles-for-sap/resource-library/sap-best-practices.html"/>).</para>
     </listitem>
    </varlistentry>
 
@@ -159,9 +161,9 @@ Resource agents, also for SAP
    </varlistentry>
   </variablelist>
 
- </sect1>
+ </section>
 
- <sect1 id="s4s-about-services">
+ <section xml:id="s4s-about-services">
   <title>Services for &sles4sap;</title>
 
   <variablelist>
@@ -185,7 +187,7 @@ Resource agents, also for SAP
    <varlistentry>
     <term><emphasis>Additional Update Channel</emphasis></term>
     <listitem>
-    <itemizedlist>
+    <itemizedlist mark="bullet" spacing="normal">
      <listitem>
       <para>
        Allows SAP-specific patches
@@ -217,11 +219,10 @@ of ownership.
      </para>
      <para>
       For background information, see SAP Note 1056161: SUSE Priority
-      Support for SAP Applications <ulink
-      url="https://launchpad.support.sap.com/#/notes/1056161"/>.
+      Support for SAP Applications <link xlink:href="https://launchpad.support.sap.com/#/notes/1056161"/>.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/xml/s4s_appendix_cryptoaddon.xml
+++ b/xml/s4s_appendix_cryptoaddon.xml
@@ -1,12 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC 
- "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<appendix id="s4s-appendix-cryptoaddon">
- <title>Downloading CryptoAddOn (SAPCryptoLib)</title>
+
+
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="s4s-appendix-cryptoaddon"><title>Downloading CryptoAddOn (SAPCryptoLib)</title><info/>
+ 
  <para>
 Starting with SAP NetWeaver 7.03/7.3 the cryptographic functionality is
 already included in the SAP NetWeaver DVDs for most countries and does
@@ -17,7 +22,7 @@ Cryptolib</emphasis>.
  </para>
 
  <para>
-SAPCRYPTOLIB is available to entitled customers and partners at <ulink url="http://www.service.sap.com/swdc"/>. Click
+SAPCRYPTOLIB is available to entitled customers and partners at <link xlink:href="http://www.service.sap.com/swdc"/>. Click
 <menuchoice>
  <guimenu>Installations and Upgrades</guimenu>
  <guimenu>Browse our Download Catalog</guimenu>

--- a/xml/s4s_appendix_docupdates.xml
+++ b/xml/s4s_appendix_docupdates.xml
@@ -1,18 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC
- "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<appendix id="ap-s4s-docupdate">
- <title>Documentation Updates</title>
+
+
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="ap-s4s-docupdate"><title>Documentation Updates</title><info/>
+ 
  <para>This section contains information about documentation content
  changes made to the <citetitle>&productname; Guide</citetitle>.
 
  </para>
  <para>This document was updated on the following dates:</para>
- <itemizedlist role="subtoc">
+ <itemizedlist role="subtoc" mark="bullet" spacing="normal">
   <listitem>
    <para><xref linkend="ap-s4s-docupdate-2016-12-08" xrefstyle="SectTitleOnPage"/></para>
   </listitem>
@@ -27,7 +32,7 @@
   </listitem>
  </itemizedlist>
  
- <sect1 id="ap-s4s-docupdate-2016-12-08">
+ <section xml:id="ap-s4s-docupdate-2016-12-08">
   <title>December 08, 2016</title>
   <para>Updates were made to the following sections. The changes are
   explained below.</para>
@@ -43,9 +48,9 @@
      </listitem>
     </varlistentry>
    </variablelist>
- </sect1>
+ </section>
 
- <sect1 id="ap-s4s-docupdate-2016-02-29">
+ <section xml:id="ap-s4s-docupdate-2016-02-29">
   <title>February 29, 2016</title>
   <para>Updates were made to the following sections. The changes are
   explained below.</para>
@@ -69,9 +74,9 @@
      </listitem>
     </varlistentry>
    </variablelist>
- </sect1>
+ </section>
 
- <sect1 id="ap-s4s-docupdate-2015-07-31">
+ <section xml:id="ap-s4s-docupdate-2015-07-31">
   <!-- FIXME: enter date -->
   <title>July 31, 2015</title>
   <para>Updates were made to the following sections. The changes are
@@ -79,8 +84,7 @@
 
    <variablelist>
     <varlistentry>
-     <term><xref linkend="s4s-inst-booting"
-     xrefstyle="SectTitleOnPage"/></term>
+     <term><xref linkend="s4s-inst-booting" xrefstyle="SectTitleOnPage"/></term>
      <listitem>
       <para>
        Add note about installing on &power;.
@@ -88,8 +92,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><xref linkend="sec-s4s-inst-wizard-sap-product-install"
-     xrefstyle="SectTitleOnPage"/></term>
+     <term><xref linkend="sec-s4s-inst-wizard-sap-product-install" xrefstyle="SectTitleOnPage"/></term>
      <listitem>
       <para>
        Update according to the new SAP media format.
@@ -97,17 +100,16 @@
      </listitem>
     </varlistentry>
    </variablelist>
- </sect1>
+ </section>
 
- <sect1 id="ap-s4s-docupdate-2013-10-28">
+ <section xml:id="ap-s4s-docupdate-2013-10-28">
   <title>October 28, 2013</title>
   <para>Updates were made to the following sections. The changes are
   explained below.</para>
 
    <variablelist>
     <varlistentry>
-     <term><xref linkend="s4s-installation"
-     xrefstyle="SectTitleOnPage"/></term>
+     <term><xref linkend="s4s-installation" xrefstyle="SectTitleOnPage"/></term>
      <listitem>
       <para>
        Update <quote>Hardware Requirements</quote>, <quote>Hard
@@ -116,8 +118,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><xref linkend="s4s-part"
-     xrefstyle="SectTitleOnPage"/></term>
+     <term><xref linkend="s4s-part" xrefstyle="SectTitleOnPage"/></term>
      <listitem>
       <para>
        New chapter.
@@ -125,8 +126,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><xref linkend="ap-s4s-docupdate"
-     xrefstyle="SectTitleOnPage"/></term>
+     <term><xref linkend="ap-s4s-docupdate" xrefstyle="SectTitleOnPage"/></term>
      <listitem>
       <para>
        New appendix.
@@ -134,5 +134,5 @@
      </listitem>
     </varlistentry>
    </variablelist>
- </sect1>
+ </section>
 </appendix>

--- a/xml/s4s_components.xml
+++ b/xml/s4s_components.xml
@@ -1,18 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<chapter id="s4s-components">
- <title>&sles4sap; Components</title>
+
+
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="s4s-components"><title>&sles4sap; Components</title><info/>
+ 
 
  <para>&sles4sapreg; consists of several components such as &sle; &hasi;,
  the Kernel page-cache limit feature, and an Installation Wizard, which
  are briefly explained in the following sections.
  </para>
 
- <sect1 id="s4s-comp-hasi">
+ <section xml:id="s4s-comp-hasi">
   <title>&sle; &hasi;</title>
 
   <para>The &sle; &hasi; add-on is part of &sles4sap;.</para>
@@ -21,20 +27,18 @@
    For more information about &sle; &hasi;, see
   </para>
 
-  <itemizedlist>
+  <itemizedlist mark="bullet" spacing="normal">
    <listitem>
-    <para>the &haguide; at <ulink
-    url="http://www.suse.com/documentation/sle_ha/"/> and</para>
+    <para>the &haguide; at <link xlink:href="http://www.suse.com/documentation/sle_ha/"/> and</para>
    </listitem>
    <listitem>
-    <para>the <emphasis>Best Practice Guides</emphasis> at <ulink
-    url="http://www.suse.com/products/sles-for-sap/resource-library/sap-best-practices.html"/>.
+    <para>the <emphasis>Best Practice Guides</emphasis> at <link xlink:href="http://www.suse.com/products/sles-for-sap/resource-library/sap-best-practices.html"/>.
     </para>
    </listitem>
   </itemizedlist>
-</sect1>
+</section>
 
-<sect1 id="sec-s4s-component-hana-replicate">
+<section xml:id="sec-s4s-component-hana-replicate">
   <title>Resource Agents for SAP HANA System Replication</title>
 
   <para>
@@ -52,7 +56,7 @@
    </para>
   </important>
 
-  <sect2 id="sec-s4s-hana-ra">
+  <section xml:id="sec-s4s-hana-ra">
    <title><systemitem>SAPHana</systemitem> Resource Agent</title>
    <!--
     Terms:
@@ -92,7 +96,7 @@
     This resource agent supports system replication for the following in
     scale-up scenarios:
    </para>
-   <itemizedlist>
+   <itemizedlist mark="bullet" spacing="normal">
     <listitem>
      <formalpara>
       <title>Performance-Optimized Scenario</title>
@@ -139,7 +143,7 @@
      <para>
       Using SAP HANA commands, you can then manually decide what to do:
      </para>
-     <itemizedlist>
+     <itemizedlist mark="bullet" spacing="normal">
       <listitem>
        <para>
         The connection between B and C can be broken, so that B can
@@ -160,8 +164,8 @@
      multi-tenant SAP HANA databases. That is, you can use SAP HANA databases that
      serve multiple SAP applications.
     </para>
-  </sect2>
-  <sect2 id="sec-s4s-topology-ra">
+  </section>
+  <section xml:id="sec-s4s-topology-ra">
    <title><systemitem>SAPHanaTopology</systemitem> Resource Agent</title>
    <para>
     To make configuring the cluster as simple as possible, SUSE has
@@ -171,13 +175,13 @@
     configurations of SAP HANA system replications. It is designed as a
     normal (stateless) clone.
    </para>
-  </sect2>
-  <sect2 id="sec-s4s-hana-replicate-more">
+  </section>
+  <section xml:id="sec-s4s-hana-replicate-more">
    <title>For More Information</title>
    <para>
     For more information, see:
    </para>
-   <itemizedlist>
+   <itemizedlist mark="bullet" spacing="normal">
     <listitem>
      <para>
       The &haguide; at &docaddress;.
@@ -192,14 +196,14 @@
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 
  <!-- page cache limit, etc. -->
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="s4s_configuration.xml"/>
+ <xi:include href="s4s_configuration.xml" parse="xml"/>
 
 
- <sect1 id="s4s-comp-wizard">
+ <section xml:id="s4s-comp-wizard">
   <title>The Installation Wizard</title>
 
   <para>
@@ -213,7 +217,7 @@
   <para>
    The Installation Wizard consists of four parts:
 </para>
-  <orderedlist>
+  <orderedlist spacing="normal">
    <listitem>
     <para>
      Installation of the operating system (&sls;).
@@ -239,7 +243,7 @@
    It is possible to run most of these parts separately.  This way, very
    flexible installation scenarios are possible.  Here are some examples:</para>
 
-  <itemizedlist>
+  <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
 Just prepare a machine with the operating system (&sls;) and run the SAP
@@ -284,7 +288,7 @@ Hier der Hinweis auf die SAP-Note mit SWAP
 
   -->
 
-  <sect2 id="s4s-comp-wizard-suppl">
+  <section xml:id="s4s-comp-wizard-suppl">
    <title>Supplement Media</title>
    <para>
     The basic idea of the <quote>Supplement Media</quote> is to enable
@@ -300,7 +304,7 @@ RPMs, running your own scripts, setting up a cluster file system or
 creating your own dialogs and scripts.
    </para>
 
-   <sect3 id="s4s-comp-wizard-suppl-productxml">
+   <section xml:id="s4s-comp-wizard-suppl-productxml">
     <title><filename>product.xml</filename></title>
 
     <para>
@@ -320,16 +324,16 @@ additional workflow.
     <para>
      The following areas or sections will be merged:
     </para>
-<screen>&lt;general>
-  &lt;ask-list>         <co id="co-s4s-ay-general"/>
+<screen>&lt;general&gt;
+  &lt;ask-list&gt;         <co xml:id="co-s4s-ay-general"/>
   ...
-&lt;software>           <co id="co-s4s-ay-software"/>
-  &lt;post-packages>
+&lt;software&gt;           <co xml:id="co-s4s-ay-software"/>
+  &lt;post-packages&gt;
   ...
-&lt;scripts>
-  &lt;chroot-scripts>   <co id="co-s4s-ay-chroot"/>
-  &lt;post-scripts>     <co id="co-s4s-ay-post"/>
-  &lt;init-scripts>     <co id="co-s4s-ay-init"/>
+&lt;scripts&gt;
+  &lt;chroot-scripts&gt;   <co xml:id="co-s4s-ay-chroot"/>
+  &lt;post-scripts&gt;     <co xml:id="co-s4s-ay-post"/>
+  &lt;init-scripts&gt;     <co xml:id="co-s4s-ay-init"/>
   ...</screen>
 <calloutlist>
  <callout arearefs="co-s4s-ay-general">
@@ -347,13 +351,13 @@ additional workflow.
    after the package installation, before the first boot
   </para>
  </callout>
- <callout  arearefs="co-s4s-ay-post">
+ <callout arearefs="co-s4s-ay-post">
   <para>
 during the first boot of the installed system, no
                       services running
   </para>
  </callout>
- <callout  arearefs="co-s4s-ay-init">
+ <callout arearefs="co-s4s-ay-init">
   <para>
 during the first boot of the installed system, all
                       services up and running
@@ -368,22 +372,21 @@ All other sections will be replaced.
  For the details of other customization options, see the SLES <emphasis>&ay;
  Guide</emphasis>, Chapter 4.12. <quote>Custom User Scripts</quote>.
 </para>
-   </sect3>
+   </section>
 
-   <sect3 id="s4s-comp-wizard-suppl-ask">
+   <section xml:id="s4s-comp-wizard-suppl-ask">
     <title>Own &ay; Ask Dialogs</title>
     <para>
      For a general overview and details of the Ask feature of &ay;, see
      Chapter 4.17.  <quote>Ask the User for Values During
      Installation</quote> of the SLES <emphasis>&ay; Guide</emphasis>
      (the <emphasis>&ay; Guide</emphasis> comes with the product or is
-     available from <ulink
-     url="http://www.suse.com/documentation/sles11/"/>).
+     available from <link xlink:href="http://www.suse.com/documentation/sles11/"/>).
     </para>
     <para>
 For the supplement media you can only use dialogs within the
 <literal>cont</literal> stage
-(<literal><![CDATA[<stage>cont</stage>]]></literal>), which means they
+(<literal>&lt;stage&gt;cont&lt;/stage&gt;</literal>), which means they
 are executed after the first reboot.
     </para>
     <para>
@@ -409,72 +412,72 @@ same answer file names and would overwrite the values saved here.
     <para>
      Here is an example with several options:
     </para>
-<screen><![CDATA[<?xml version="1.0"?>
-<!DOCTYPE profile>
-<profile xmlns="http://www.suse.com/1.0/yast2ns"
-         xmlns:config="http://www.suse.com/1.0/configns">
-<general>
-  <ask-list config:type="list">
-      <ask>
-          <stage>cont</stage>
-          <dialog config:type="integer">20</dialog>
-          <element config:type="integer">10</element>
-          <question>What is your name?</question>
-          <default>Enter your name here</default>
-          <help>Please enter your full name within the field</help>
-          <file>/tmp/ay_q_my_name</file>
-          <script>
-             <filename>my_name.sh</filename>
-             <rerun_on_error config:type="boolean">true</rerun_on_error>
-             <environment config:type="boolean">true</environment>
-             <source><![CDATA[
+<screen>&lt;?xml version="1.0"?&gt;
+&lt;!DOCTYPE profile&gt;
+&lt;profile xmlns="http://www.suse.com/1.0/yast2ns"
+         xmlns:config="http://www.suse.com/1.0/configns"&gt;
+&lt;general&gt;
+  &lt;ask-list config:type="list"&gt;
+      &lt;ask&gt;
+          &lt;stage&gt;cont&lt;/stage&gt;
+          &lt;dialog config:type="integer"&gt;20&lt;/dialog&gt;
+          &lt;element config:type="integer"&gt;10&lt;/element&gt;
+          &lt;question&gt;What is your name?&lt;/question&gt;
+          &lt;default&gt;Enter your name here&lt;/default&gt;
+          &lt;help&gt;Please enter your full name within the field&lt;/help&gt;
+          &lt;file&gt;/tmp/ay_q_my_name&lt;/file&gt;
+          &lt;script&gt;
+             &lt;filename&gt;my_name.sh&lt;/filename&gt;
+             &lt;rerun_on_error config:type="boolean"&gt;true&lt;/rerun_on_error&gt;
+             &lt;environment config:type="boolean"&gt;true&lt;/environment&gt;
+             &lt;source&gt;&lt;![CDATA[
 function check_name() {
            local name=$1
            LC_ALL=POSIX
-           [ -z "$name" ] && echo "You need to provide a name." && return 1
+           [ -z "$name" ] &amp;&amp; echo "You need to provide a name." &amp;&amp; return 1
            return 0
 }
 check_name "$VAL"
-]]>]<![CDATA[]>
-             </source>
-             <debug config:type="boolean">false</debug>
-             <feedback config:type="boolean">true</feedback>
-          </script>
-      </ask>
-  </ask-list>
-</general>
-</profile>]]></screen>
-   </sect3>
-   <sect3 id="s4s-comp-wizard-suppl-addpacks">
+]]&gt;
+             &lt;/source&gt;
+             &lt;debug config:type="boolean"&gt;false&lt;/debug&gt;
+             &lt;feedback config:type="boolean"&gt;true&lt;/feedback&gt;
+          &lt;/script&gt;
+      &lt;/ask&gt;
+  &lt;/ask-list&gt;
+&lt;/general&gt;
+&lt;/profile&gt;</screen>
+   </section>
+   <section xml:id="s4s-comp-wizard-suppl-addpacks">
     <title>Install Additional Packages</title>
     <para>
 You can also install RPM packages within the
 <filename>product.xml</filename> file. To do this, you can use the
-<literal>&lt;post-packages></literal> element for installation in stage 2.
+<literal>&lt;post-packages&gt;</literal> element for installation in stage 2.
     </para>
     <para>
      For more information, see the SLES &ay; Guide, Chapter
      4.5.6. <quote>Installing Packages during Stage 2</quote>.  An
      example looks as follows:
     </para>
-<screen><![CDATA[...
-<software>
- <post-packages config:type="list">
-  <package>yast2-cim</package>
- </post-packages>
-</software>
-...]]></screen>
-   </sect3>
-   <sect3>
+<screen>...
+&lt;software&gt;
+ &lt;post-packages config:type="list"&gt;
+  &lt;package&gt;yast2-cim&lt;/package&gt;
+ &lt;/post-packages&gt;
+&lt;/software&gt;
+...</screen>
+   </section>
+   <section>
     <title>Example Directory for the Supplement Media</title>
     <screen># ls
 /
 |--product.xml
 </screen>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2  id="s4s-comp-clamsap">
+  <section xml:id="s4s-comp-clamsap">
    <title>ClamSAP</title>
    <para>
 ClamSAP is a new antivirus toolkit integration with the SAP Virus Scan
@@ -486,8 +489,7 @@ scan interface of SAP (NW-VSI). An SAP application can use the ClamAV
 engine to scan for malicious uploads in HTTP uploads for example. If you
 want to use Virus Scan within SAP applications, you can use Virus Scan
 Interface in SAP (<menuchoice><guimenu>Transaction</guimenu><guimenu>VSCAN</guimenu></menuchoice>).
-There is an open source adapter for the ClamAV engine at <ulink
-url="http://freshmeat.net/projects/clamsap/"/>. The library allows
+There is an open source adapter for the ClamAV engine at <link xlink:href="http://freshmeat.net/projects/clamsap/"/>. The library allows
 integration of ClamAV into SAP and works also on Unix, where most other
 antivirus products do not run.</para>
 
@@ -497,8 +499,8 @@ Trojans, viruses, malware, and other malicious threats. It is the de
 facto standard for mail gateway scanning. It provides a high performance
 multi-threaded scanning daemon, command line utilities for on-demand
 file scanning, and an intelligent tool for automatic signature updates.
-For more information, see <ulink url="http://www.clamav.net"/>.</para>
-  </sect2>
- </sect1>
+For more information, see <link xlink:href="http://www.clamav.net"/>.</para>
+  </section>
+ </section>
 
 </chapter>

--- a/xml/s4s_configuration.xml
+++ b/xml/s4s_configuration.xml
@@ -1,16 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<sect1 id="s4s-configuration">
+
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="s4s-configuration">
 
  <title>Configuring &sles4sap;</title>
  <para>
  </para>
 
- <sect2 id="s4s-config-page-cache">
+ <section xml:id="s4s-config-page-cache">
 
   <title>Kernel: Page-Cache Limit</title>
 
@@ -55,7 +61,7 @@
      <para>
       Two new kernel options are available for configuration:
      </para>
-     <itemizedlist>
+     <itemizedlist mark="bullet" spacing="normal">
       <listitem>
        <para>
         vm.pagecache_limit_mb (/proc/sys/vm/pagecache_limit_mb)
@@ -75,15 +81,14 @@ vm.pagecache_limit_ignore_dirty = 0</screen>
 
      <para>
       For background information, see SAP Note 1557506: Linux paging
-      improvements <ulink
-      url="https://launchpad.support.sap.com/#/notes/1557506"/>.
+      improvements <link xlink:href="https://launchpad.support.sap.com/#/notes/1557506"/>.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
- </sect2>
+ </section>
  <!-- ==================================================================== -->
- <sect2 id="s4s-config-ports">
+ <section xml:id="s4s-config-ports">
 
   <title>Ports Configuration</title>
 
@@ -92,7 +97,7 @@ vm.pagecache_limit_ignore_dirty = 0</screen>
    firewall.  The exact numbers depend on the selected instances, for
    example:
   </para>
-  <itemizedlist>
+  <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>3200-3399,</para>
    </listitem>
@@ -123,16 +128,16 @@ vm.pagecache_limit_ignore_dirty = 0</screen>
    </para>
   </warning>
 
- </sect2>
+ </section>
 
- <sect2 id="s4s-config-logs">
+ <section xml:id="s4s-config-logs">
   <title>Important Log Files</title>
 
   <para>
    The most important files for this product are:
   </para>
 
-  <itemizedlist>
+  <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
      Auto-installation related log files are in
@@ -152,7 +157,7 @@ vm.pagecache_limit_ignore_dirty = 0</screen>
    </listitem>
   </itemizedlist>
 
- </sect2>
+ </section>
 
 <!--
  <sect2>
@@ -161,4 +166,4 @@ vm.pagecache_limit_ignore_dirty = 0</screen>
   <para>For more information about tuning &sls; see the SLES &tuning;.</para>
  </sect2>
 -->
-</sect1>
+</section>

--- a/xml/s4s_install_network.xml
+++ b/xml/s4s_install_network.xml
@@ -1,24 +1,29 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<chapter id="s4s-inst-remote">
- <title>Remote Installation from a Network Server</title>
+
+
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="s4s-inst-remote"><title>Remote Installation from a Network Server</title><info/>
+ 
 
  <para>
   For detailed information about installing &sls; from a network server
   in general, see the &deploy;, Chapter 14, <quote>Remote
   Installation</quote> (the &deploy; comes with the product or is
-  available from <ulink
-  url="http://www.suse.com/documentation/sles11/"/>).
+  available from <link xlink:href="http://www.suse.com/documentation/sles11/"/>).
  </para>
 
  <para>The following section provides a short description about
  installing from a network server.</para>
 
- <sect1>
+ <section>
   <title>Installing with Installation Media from the Network</title>
   <procedure>
    <step>
@@ -34,7 +39,7 @@
    <step>
     <para>Choose one of the boot menu options and edit the command
     line:</para>
-    <orderedlist>
+    <orderedlist spacing="normal">
      <listitem>
       <para>
        remove the parameter <literal>instmode=cd</literal> from the command
@@ -68,11 +73,10 @@
     avoid using a DVD to bootstrap the system and boot from the network
     via PXE, read the <emphasis>&ay; Guide</emphasis> about setting up a
     PXE environment (the <emphasis>&ay; Guide</emphasis> comes with the
-    product or is available from <ulink
-    url="http://www.suse.com/documentation/sles11/"/>).</para>
- </sect1>
+    product or is available from <link xlink:href="http://www.suse.com/documentation/sles11/"/>).</para>
+ </section>
 
- <sect1>
+ <section>
   <title>Copying SAP Media Sets from a Remote Server with the
   Installation Wizard</title>
 
@@ -132,5 +136,5 @@
   14.2.2.
  </para>
 
- </sect1>
+ </section>
 </chapter>

--- a/xml/s4s_installation.xml
+++ b/xml/s4s_installation.xml
@@ -1,18 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<chapter id="s4s-installation">
- <title>Default Installation Scenarios</title>
+
+
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="s4s-installation"><title>Default Installation Scenarios</title><info/>
+ 
 
   <para>After planning the installation with downloading the software
   and checking the minimal hardware requirements, there are three
   default installation scenarios:
   </para>
 
-  <itemizedlist>
+  <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
      <xref linkend="s4s-inst-inst" xrefstyle="select:title,nopage"/>
@@ -30,7 +36,7 @@
    </listitem>
   </itemizedlist>
 
- <sect1 id="s4s-inst-planning">
+ <section xml:id="s4s-inst-planning">
   <title>Planning the Installation</title>
 
   <para>
@@ -38,7 +44,7 @@
    minimal hardware requirements.
   </para>
 
-  <sect2>
+  <section>
    <title>Download and Installation Preparations</title>
 
   <procedure>
@@ -63,10 +69,10 @@
    </step>
    -->
   </procedure>
- </sect2>
+ </section>
 
  <!-- ================================================================== -->
- <sect2>
+ <section>
   <title>Hardware Requirements</title>
 
   <variablelist>
@@ -87,12 +93,12 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </sect2>
+ </section>
 
-</sect1>
+</section>
 
 
- <sect1 id="s4s-inst-booting">
+ <section xml:id="s4s-inst-booting">
  <title>Booting the Installation Medium</title>
  <para>
   Different scenarios are available to install &sles4sap; 11.  Select
@@ -113,7 +119,7 @@
   </para>
  </note>
 
- <figure id="fig-s4s-dvd-bootmenu">
+ <figure xml:id="fig-s4s-dvd-bootmenu">
   <title>DVD Boot Menu</title>
   <mediaobject>
    <imageobject role="fo">
@@ -162,8 +168,7 @@
   </varlistentry>
   <varlistentry>
    <term><guimenu>SLES for SAP Applications &mdash; Installation with
-   External Profile</guimenu> (see <xref
-   linkend="s4s-inst-profile"/>)</term>
+   External Profile</guimenu> (see <xref linkend="s4s-inst-profile"/>)</term>
    <listitem>
     <para>This installation is driven by a user-provided &ay;
     profile.  There are no &suse;-provided SAP optimizations.</para>
@@ -179,8 +184,7 @@
     <para>
      Starting a minimal Linux system without a graphical user
     interface. For more information, see the &admin;, Chapter 34, Common
-    Problems and Their Solutions; find the &admin; at <ulink
-    url="https://www.suse.com/documentation/sles11/"/>.
+    Problems and Their Solutions; find the &admin; at <link xlink:href="https://www.suse.com/documentation/sles11/"/>.
     </para>
    </listitem>
   </varlistentry>
@@ -194,9 +198,9 @@
    </listitem>
   </varlistentry>
  </variablelist>
- </sect1>
+ </section>
 
- <sect1 id="s4s-inst-inst">
+ <section xml:id="s4s-inst-inst">
   <title><guimenu>SLES for SAP Applications &mdash;
   Installation</guimenu></title>
   <para>
@@ -223,9 +227,9 @@
    partitioning of storage devices, network, or software packages.
   </para>
 
- </sect1>
+ </section>
 
- <sect1 id="s4s-inst-wizard">
+ <section xml:id="s4s-inst-wizard">
   <title><guimenu>SLES for SAP Applications &mdash; Installation with
   Wizard</guimenu></title>
   <para>
@@ -239,7 +243,7 @@
    required or possible.
   </para>
 
- <sect2>
+ <section>
   <title>Data Required for Installing the System (with Wizard)</title>
 
   <para>
@@ -248,7 +252,7 @@
   </para>
 
   <informaltable>
-     <tgroup cols = "2">
+     <tgroup cols="2">
       <tbody>
        <row>
         <entry>
@@ -348,7 +352,7 @@
   </para>
 
   <informaltable>
-     <tgroup cols = "2">
+     <tgroup cols="2">
       <tbody>
        <row>
         <entry>
@@ -443,10 +447,10 @@
   </informaltable>
 
   <para>(*) not required for TREX.</para>
- </sect2>
+ </section>
 
 
-  <sect2 id="s4s-inst-wizard-boot">
+  <section xml:id="s4s-inst-wizard-boot">
    <title>Selecting <guimenu>SLES for SAP Applications &mdash;
    Installation with Wizard</guimenu> from the DVD Boot Menu</title>
    <para>
@@ -459,9 +463,9 @@
     &yast; installation program starts and displays the graphical
     installer, which will run mostly automatically.
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-s4s-inst-wizard-prepauto">
+  <section xml:id="sec-s4s-inst-wizard-prepauto">
    <title>Preparing System for Automated Installation</title>
    <para>
     After analyzing your computer, the next &yast; pop-up dialog will let
@@ -470,7 +474,7 @@
     you select the SAP Application.
    </para>
 
-   <figure id="fig-s4s-inst-yast-storage-system">
+   <figure xml:id="fig-s4s-inst-yast-storage-system">
     <title>System Volume Configuration</title>
     <mediaobject>
      <imageobject role="fo">
@@ -485,8 +489,7 @@
    <para>
     If there is just one hard disk, keep it as the system volume device
     and set the size of the system volume (and the swap space) in GB in
-    the lower field and confirm it; see <xref
-    linkend="fig-s4s-inst-yast-storage-system"/>.
+    the lower field and confirm it; see <xref linkend="fig-s4s-inst-yast-storage-system"/>.
    </para>
 
    <tip>
@@ -494,8 +497,7 @@
     <para>
      Normally, at least 10 GB is required for the system volume.  The
      swap space depends on the available main memory (RAM).  For more
-     information, see the SAP Note 1597355: <ulink
-     url="https://launchpad.support.sap.com/#/notes/1597355"/>.
+     information, see the SAP Note 1597355: <link xlink:href="https://launchpad.support.sap.com/#/notes/1597355"/>.
     </para>
    </tip>
 
@@ -519,9 +521,9 @@
     After confirmation, &yast; performs the software installation.
     Packages are installed one by one, so you can see the progress.
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-s4s-inst-wizard-yast2-user-root">
+  <section xml:id="sec-s4s-inst-wizard-yast2-user-root">
    <title>Password for the System Administrator &rootuser;</title><indexterm>
    <primary>&yast;</primary>
    <secondary>root password</secondary></indexterm><indexterm>
@@ -534,7 +536,7 @@
     &rootuser;; see <xref linkend="fig-s4s-inst-yast-root-password"/>.
    </para>
 
-   <figure id="fig-s4s-inst-yast-root-password">
+   <figure xml:id="fig-s4s-inst-yast-root-password">
     <title>Password for root User</title>
     <mediaobject>
      <imageobject role="fo">
@@ -576,9 +578,9 @@
      password.
     </para>
    </warning>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-s4s-inst-wizard-yast2-conf-manual-hostname">
+  <section xml:id="sec-s4s-inst-wizard-yast2-conf-manual-hostname">
    <title>Hostname, Domain Name, and IP Address</title><indexterm>
    <primary>&yast;</primary>
     <secondary>hostname</secondary></indexterm><indexterm>
@@ -591,11 +593,10 @@
    </indexterm>
 
    <para>
-    The next dialog starts with the network configuration; see <xref
-    linkend="fig-s4s-inst-yast-network-config"/>.
+    The next dialog starts with the network configuration; see <xref linkend="fig-s4s-inst-yast-network-config"/>.
    </para>
 
-   <figure id="fig-s4s-inst-yast-network-config">
+   <figure xml:id="fig-s4s-inst-yast-network-config">
     <title>Hostname, Domain Name, and IP Address</title>
     <mediaobject>
      <imageobject role="fo">
@@ -622,17 +623,16 @@
      unique and the netmask has to be common to all hosts on the
      network.
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-s4s-inst-wizard-yast2-conf-manual-dns-ntp">
+  <section xml:id="sec-s4s-inst-wizard-yast2-conf-manual-dns-ntp">
    <title>Domain Name Service (DNS) and Time Server (NTP)</title>
 
    <para>
-    The next dialog continues with the network configuration; see <xref
-    linkend="fig-s4s-inst-yast-network-config2"/>.
+    The next dialog continues with the network configuration; see <xref linkend="fig-s4s-inst-yast-network-config2"/>.
    </para>
 
-   <figure id="fig-s4s-inst-yast-network-config2">
+   <figure xml:id="fig-s4s-inst-yast-network-config2">
     <title>Domain Name Service (DNS) and Time Server (NTP)</title>
     <mediaobject>
      <imageobject role="fo">
@@ -655,20 +655,18 @@
      synchronize automatically via Network Time Protocol (NTP).
     </para>
 
-   </sect2>
+   </section>
 
-   <sect2 id="sec-s4s-inst-wizard-yast2-conf-manual-reg">
+   <section xml:id="sec-s4s-inst-wizard-yast2-conf-manual-reg">
     <title>Registration</title>
     <!-- 215-yast-registration.png -->
 
     <para>
      To get technical support and product updates, you need to register
-     and activate your product with the &ncc;; see <xref
-     linkend="fig-s4s-inst-yast-reg"/>.  This dialog provides assistance
-     for doing so. Find detailed information about &ncc; at <ulink
-     url="http://www.novell.com/documentation/ncc/"/>.
+     and activate your product with the &ncc;; see <xref linkend="fig-s4s-inst-yast-reg"/>.  This dialog provides assistance
+     for doing so. Find detailed information about &ncc; at <link xlink:href="http://www.novell.com/documentation/ncc/"/>.
     </para>
-   <figure id="fig-s4s-inst-yast-reg">
+   <figure xml:id="fig-s4s-inst-yast-reg">
     <title>Registration</title>
     <mediaobject>
      <imageobject role="fo">
@@ -686,9 +684,9 @@
      provide the registration code now, operating system updates will be
      installed automatically during the installation of the system.
     </para>
-   </sect2>
+   </section>
 
-   <sect2>
+   <section>
     <title>System Configuration Settings</title>
     <para>
      After confirming the registration data, the system will be
@@ -713,14 +711,13 @@
      </para>
     </warning>
 
-   </sect2>
+   </section>
 
-   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-               href="s4s_installation_sap.xml"/>
+   <xi:include href="s4s_installation_sap.xml" parse="xml"/>
 
-   </sect1>
+   </section>
 
-   <sect1 id="s4s-inst-profile">
+   <section xml:id="s4s-inst-profile">
     <title><guimenu>SLES for SAP Applications &mdash;
     Installation with External Profile</guimenu></title>
 
@@ -731,8 +728,7 @@
      their own &ay; profiles to install &sles4sap;.  For more
      information about &ay; profiles, see the SLES <emphasis>&ay;
      Guide</emphasis> (the <emphasis>&ay; Guide</emphasis> comes
-      with the product or is available from <ulink
-      url="http://www.suse.com/documentation/sles11/"/>).
+      with the product or is available from <link xlink:href="http://www.suse.com/documentation/sles11/"/>).
     </para>
 
     <para>
@@ -762,7 +758,7 @@
      <filename>autoyast.xml</filename> file.
     </para>
 
-    <sect2>
+    <section>
      <title>About &ay;</title>
 
      <para>
@@ -777,12 +773,11 @@
      <para>
       For more information about &ay;, see the <emphasis>&sls; 11 &ay;
       Guide</emphasis> (the <emphasis>&ay; Guide</emphasis> comes
-      with the product or is available from <ulink
-      url="http://www.suse.com/documentation/sles11/"/>).
+      with the product or is available from <link xlink:href="http://www.suse.com/documentation/sles11/"/>).
      </para>
-    </sect2>
+    </section>
 
-    <sect2>
+    <section>
      <title>Partitioning with &ay;</title>
 
      <para>
@@ -793,11 +788,10 @@
      </para>
 
      <para>
-      For background information on partitioning, see <xref
-      linkend="s4s-part"/>.
+      For background information on partitioning, see <xref linkend="s4s-part"/>.
      </para>
-    </sect2>
+    </section>
 
-   </sect1>
+   </section>
 
 </chapter>

--- a/xml/s4s_installation_sap.xml
+++ b/xml/s4s_installation_sap.xml
@@ -1,10 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect2 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect2
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<sect2 id="sec-s4s-inst-wizard-sap-product-install">
+
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="sec-s4s-inst-wizard-sap-product-install">
 <!-- 220-yast-start-sap-install.png -->
     <title>SAP Product Installation</title>
 
@@ -32,8 +38,7 @@
      <step>
    <para>
     Select <guimenu>Create SAP file systems and start SAP product
-    installation</guimenu> and confirm the pop-up (see <xref
-    linkend="fig-s4s-inst-yast-start-sap-install"/>) if you want to
+    installation</guimenu> and confirm the pop-up (see <xref linkend="fig-s4s-inst-yast-start-sap-install"/>) if you want to
     continue with the installation right away.
    </para>
    <para>
@@ -53,7 +58,7 @@
      instructions in <citetitle>SAP Note 1944415: Hardware Configuration
      Guide and Software Installation Guide for SUSE Linux Enterprise Server
      with SAP HANA and SAP Business One</citetitle>
-     (<ulink url="https://launchpad.support.sap.com/#/notes/1944415"/>).
+     (<link xlink:href="https://launchpad.support.sap.com/#/notes/1944415"/>).
     </para>
     <para>
      Otherwise, this option will not create a new file system and the
@@ -61,7 +66,7 @@
     </para>
    </important>
 
-    <figure id="fig-s4s-inst-yast-start-sap-install">
+    <figure xml:id="fig-s4s-inst-yast-start-sap-install">
     <title>SAP Product Installation</title>
     <mediaobject>
      <imageobject role="fo">
@@ -81,8 +86,7 @@
      select the <guimenu>SAP Product Installer</guimenu>
      (<guimenu>Computer</guimenu>, then in the YaST Control Center click
      <menuchoice><guimenu>Miscellaneous</guimenu><guimenu>SAP Product
-     Installer</guimenu></menuchoice>; see <xref
-     linkend="fig-s4s-ycc-sap-product-installer"/>).  The functionality
+     Installer</guimenu></menuchoice>; see <xref linkend="fig-s4s-ycc-sap-product-installer"/>).  The functionality
      is the same, but the layout of the dialogs is different; the left
      progress pane is only displayed when continuing with the
      installation without a restart.
@@ -95,7 +99,7 @@
    </tip>
 
 
-   <figure id="fig-s4s-ycc-sap-product-installer">
+   <figure xml:id="fig-s4s-ycc-sap-product-installer">
     <title>&yast; Control Center: SAP Product Installer</title>
     <mediaobject>
      <imageobject role="fo">
@@ -111,8 +115,7 @@
      <step>
    <para>
     In the next dialog provide the <guimenu>Location of the SAP
-    Installation Master</guimenu>; see <xref
-    linkend="fig-s4s-sap-wizard-source"/>.  The location can either be a
+    Installation Master</guimenu>; see <xref linkend="fig-s4s-sap-wizard-source"/>.  The location can either be a
     local source or a remotely provided installation source.
    </para>
 
@@ -120,7 +123,7 @@
     <varlistentry>
      <term>Local Source</term>
      <listitem>
-      <itemizedlist>
+      <itemizedlist mark="bullet" spacing="normal">
        <listitem>
         <para>a directory (<literal>dir://</literal> and <literal><replaceable>/path/to/dir/</replaceable></literal>)</para>
        </listitem>
@@ -146,7 +149,7 @@
     <varlistentry>
      <term>A Remotely Provided Installation Source</term>
       <listitem>
-       <itemizedlist>
+       <itemizedlist mark="bullet" spacing="normal">
         <listitem>
          <para>
           NFS (<literal>nfs://</literal> and <literal><replaceable>server_name</replaceable>/<replaceable>/path/to/dir/on/server</replaceable></literal>)
@@ -177,7 +180,7 @@
     </para>
    </tip>
 
-   <figure id="fig-s4s-sap-wizard-source">
+   <figure xml:id="fig-s4s-sap-wizard-source">
     <title>SAP Installation Wizard: SAP Installation Master Location</title>
     <mediaobject>
      <imageobject role="fo">
@@ -213,11 +216,10 @@
        Engines</guimenu>, etc. and the <guimenu>Database</guimenu> such
        as <guimenu>IBM DB2</guimenu>, <guimenu>MaxDB</guimenu>, etc. you
        want to deploy. In the case of a B1 or HANA installation, such a
-       selection does not exist.  See <xref
-       linkend="fig-s4s-sap-wizard-mode-db"/>.  Click
+       selection does not exist.  See <xref linkend="fig-s4s-sap-wizard-mode-db"/>.  Click
        <guimenu>Help</guimenu> for information.
       </para>
-   <figure id="fig-s4s-sap-wizard-mode-db">
+   <figure xml:id="fig-s4s-sap-wizard-mode-db">
     <title>SAP Installation Wizard: Installation Mode and Database</title>
     <mediaobject>
      <imageobject role="fo">
@@ -263,7 +265,7 @@
     example, see <xref linkend="fig-s4s-sap-wizard-avail-products"/>.
    </para>
 
-    <figure id="fig-s4s-sap-wizard-avail-products">
+    <figure xml:id="fig-s4s-sap-wizard-avail-products">
      <title>SAP Installation Wizard: SAP Products</title>
      <mediaobject>
       <imageobject role="fo">
@@ -277,7 +279,7 @@
 
      </step>
      <!-- ============================================================ -->
-     <step id="pro-sap-wizard-products">
+     <step xml:id="pro-sap-wizard-products">
       <para>
        For example, select <guimenu>SAP NetWeaver 7.4</guimenu> and
        click <guimenu>Next</guimenu>.  Now the relevant part of the SAP
@@ -292,8 +294,7 @@
       <para>
        You are asked to provide the <guimenu>Location of the SAP
        Medium</guimenu> and if additional media are needed, you can also
-       add them afterwards; see <xref
-       linkend="fig-s4s-sap-wizard-sapmedia "/> (here you see the list
+       add them afterwards; see <xref linkend="fig-s4s-sap-wizard-sapmedia "/> (here you see the list
        of already copied or linked SAP media).  Click
        <guimenu>Help</guimenu> for information.
        <!--
@@ -314,7 +315,7 @@
      </mediaobject>
      </figure>
      -->
-      <figure id="fig-s4s-sap-wizard-sapmedia">
+      <figure xml:id="fig-s4s-sap-wizard-sapmedia">
      <title>SAP Installation Wizard: Additional SAP Media</title>
      <mediaobject>
       <imageobject role="fo">
@@ -486,7 +487,7 @@ drwxr-xr-x  4 root root 4096 Sep 27 14:07 RDBMS-ADA/
       <para>
        First, specify the <guimenu>System T-Shirt-Sizing</guimenu>.
       </para>
-    <figure id="fig-s4s-sap-wizard-sysparams-size">
+    <figure xml:id="fig-s4s-sap-wizard-sysparams-size">
     <title>SAP System Parameters: T-Shirt-Sizing</title>
     <mediaobject>
      <imageobject role="fo">
@@ -530,7 +531,7 @@ drwxr-xr-x  4 root root 4096 Sep 27 14:07 RDBMS-ADA/
     enter the virtual network settings, if needed.  For details, see the
     online help on the left.
    </para>
-    <figure id="fig-s4s-sap-wizard-virt-params">
+    <figure xml:id="fig-s4s-sap-wizard-virt-params">
     <title>SAP Virtual Network Settings</title>
     <mediaobject>
      <imageobject role="fo">
@@ -603,7 +604,7 @@ drwxr-xr-x  4 root root 4096 Sep 27 14:07 RDBMS-ADA/
         ID, password for all users, database ID,
     -->
    </para>
-    <figure id="fig-s4s-sapinst-param">
+    <figure xml:id="fig-s4s-sapinst-param">
     <title>SAP Installer (SAPinst): Defining Parameters</title>
     <mediaobject>
      <imageobject role="fo">
@@ -616,10 +617,9 @@ drwxr-xr-x  4 root root 4096 Sep 27 14:07 RDBMS-ADA/
    </figure>
 
    <para>The SAP installer displays a
-    visualization of the installation steps it performs; see <xref
-    linkend="fig-s4s-sapinst"/>.
+    visualization of the installation steps it performs; see <xref linkend="fig-s4s-sapinst"/>.
    </para>
-    <figure id="fig-s4s-sapinst">
+    <figure xml:id="fig-s4s-sapinst">
     <title>SAP Installer (SAPinst)</title>
     <mediaobject>
      <imageobject role="fo">
@@ -674,4 +674,4 @@ usw.
      -->
 
 
-   </sect2>
+   </section>

--- a/xml/s4s_overview.xml
+++ b/xml/s4s_overview.xml
@@ -1,12 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd"
-          [
-          <!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-          <!ENTITY % entities SYSTEM "entity-decl.ent">
-          %entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE preface
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<preface id="pre-smt">
- <title>About This Guide</title>
+
+
+<preface xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="pre-smt"><title>About This Guide</title><info/>
+ 
  <para>
   &sles4sapreg; is the reference platform for SAP's software
   development.  It is optimized in various ways for SAP applications.
@@ -17,7 +22,7 @@
   &sls; &hasi; is also part of &sles4sap;.
  </para>
 <!-- -=-=-=-=-=-=-=-=-=-=-=-=-=- cut here -=-=-=-=-=-=-=-=-=-=-=-=-=- -->
- <sect1>
+ <section>
   <title>Overview</title>
 
   <para>
@@ -63,9 +68,9 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 <!-- -=-=-=-=-=-=-=-=-=-=-=-=-=- cut here -=-=-=-=-=-=-=-=-=-=-=-=-=- -->
- <sect1>
+ <section>
   <title>Additional Documentation and Resources</title>
 
   <para>
@@ -76,10 +81,10 @@
   <para>
    For an overview of the documentation available for your product and the
    latest documentation updates, refer to
-   <ulink url="http://www.suse.com/documentation"/>.
+   <link xlink:href="http://www.suse.com/documentation"/>.
   </para>
- </sect1>
+ </section>
 <!-- -=-=-=-=-=-=-=-=-=-=-=-=-=- cut here -=-=-=-=-=-=-=-=-=-=-=-=-=- -->
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_feedback_i.xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_feedback_i.xml" parse="xml"/>
+ <xi:include href="common_intro_typografie_i.xml" parse="xml"/>
 </preface>

--- a/xml/s4s_partitioning.xml
+++ b/xml/s4s_partitioning.xml
@@ -1,26 +1,29 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<chapter id="s4s-part">
- <title>Background Information on Partitioning</title>
+
+
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="s4s-part"><title>Background Information on Partitioning</title><info/>
+ 
 
  <para>
   During installation partitioning will be done in two steps.  The first
-  step happens while installing the operating system (stage 1, see <xref
-  linkend="sec-s4s-inst-wizard-prepauto"/>), and the second step while
-  installing your SAP product (stage 2, see <xref
-  linkend="sec-s4s-inst-wizard-sap-product-install"/>).
+  step happens while installing the operating system (stage 1, see <xref linkend="sec-s4s-inst-wizard-prepauto"/>), and the second step while
+  installing your SAP product (stage 2, see <xref linkend="sec-s4s-inst-wizard-sap-product-install"/>).
  </para>
 
- <sect1 id="sec-s4s-part-inst">
+ <section xml:id="sec-s4s-part-inst">
   <title>Stage 1: Partitioning for the Operating System</title>
 
   <para>
-   During stage 1 of the installation (see <xref
-   linkend="sec-s4s-inst-wizard-prepauto"/>), partitions for the
+   During stage 1 of the installation (see <xref linkend="sec-s4s-inst-wizard-prepauto"/>), partitions for the
    operating system will be created.
   </para>
 
@@ -30,8 +33,7 @@
    <literal>root_lv</literal> and <literal>swap_lv</literal>.
 
    The size of <literal>swap_lv</literal> will be calculated according
-   to the SAP Note 1597355 (<ulink
-   url="https://launchpad.support.sap.com/#/notes/1597355"/>).  For
+   to the SAP Note 1597355 (<link xlink:href="https://launchpad.support.sap.com/#/notes/1597355"/>).  For
    <literal>root_lv</literal>, 35 GB will be assumed at first, and the
    sum of <literal>root_lv</literal> and <literal>swap_lv</literal> will
    be displayed as <guimenu>Set the system volume size in GB</guimenu>.
@@ -44,7 +46,7 @@
    this, mind some caveats:
   </para>
     
-  <itemizedlist>
+  <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
      The size of the system volume could not exceed the physical size
@@ -72,9 +74,9 @@
     size of the system volume, error messages are issued.
    </para>
   </note>
- </sect1>
+ </section>
  <!-- ============================================================ -->
- <sect1 id="sec-s4s-part-sap">
+ <section xml:id="sec-s4s-part-sap">
   <title>Stage 2: Partitioning for the SAP System</title>
   <para>
    After installing the operating system the partitioning for the SAP
@@ -93,11 +95,11 @@
 
   <para>
    In <filename>/etc/sap-installation-wizard.xml</filename> the
-   <literal><![CDATA[<partitioning>]]></literal> tag defines for which
+   <literal>&lt;partitioning&gt;</literal> tag defines for which
    SAP programs which files for controlling the partitioning are used.
    These files will be taken from
    <filename>/usr/share/YaST2/include/sap-installation-wizard/</filename>.
-   In case there is no <literal><![CDATA[<partitioning>]]></literal> tag
+   In case there is no <literal>&lt;partitioning&gt;</literal> tag
    for the wanted SAP product,
    <filename>base_partitioning.xml</filename> will be used.
   </para>
@@ -108,10 +110,10 @@
    extensions:
   </para>
 
-  <itemizedlist>
+  <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     If the <literal><![CDATA[<partitioning_defined>]]></literal> tag is
+     If the <literal>&lt;partitioning_defined&gt;</literal> tag is
      set to <literal>true</literal>, the partitioning will be performed
      without any user interaction.  This, for example, is preconfigured
      in files for controlling the partitioning of known hardware such as
@@ -123,10 +125,9 @@
    <listitem>
     <para>
      For every partition you can specify the
-     <literal><![CDATA[<size_min>]]></literal> tag.  The size value can
+     <literal>&lt;size_min&gt;</literal> tag.  The size value can
      be given as a string in the format of
-     <literal><replaceable>RAM</replaceable>*<replaceable
-     >N</replaceable></literal>.  This way you can specify, how large
+     <literal><replaceable>RAM</replaceable>*<replaceable>N</replaceable></literal>.  This way you can specify, how large
      the partition should be minimally (x-times
      (<replaceable>N</replaceable>) the size of the available memory
      (<replaceable>RAM</replaceable>)).
@@ -157,7 +158,7 @@
      In <filename>/etc/sap-installation-wizard.xml</filename>, at the
      <literal>TREX</literal> following tag insert:
     </para>
-    <screen><![CDATA[<partitioning>TREX_partitioning.xml</partitioning>]]></screen>
+    <screen>&lt;partitioning&gt;TREX_partitioning.xml&lt;/partitioning&gt;</screen>
    </step>
   </procedure>
   <warning>
@@ -174,6 +175,5 @@
    the <emphasis>&ay; Guide</emphasis>.
   </para>
 
- </sect1>
+ </section>
 </chapter>
-  

--- a/xml/s4s_qinstall.xml
+++ b/xml/s4s_qinstall.xml
@@ -1,11 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd" [
-<!ENTITY % NOVDOC.DEACTIVATE.IDREF "INCLUDE">
-<!ENTITY % entities SYSTEM "entity-decl.ent">
-%entities;
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter
+[
+   <!ENTITY % entities SYSTEM "entity-decl.ent">
+   %entities;
 ]>
-<chapter id="s4s-qinstallation">
- <title>Quick Installation of &sles4sap;</title>
+
+
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="s4s-qinstallation"><title>Quick Installation of &sles4sap;</title><info/>
+ 
  <para>
   &slsreg; optimized for SAP applications is available as a downloadable
   DVD image.  The image can be deployed automatically&mdash;including
@@ -15,7 +21,7 @@
   The current release of the product is based on &sls; &productnumber;.
  </para>
  <!-- ================================================================== -->
- <sect1 id="s4s-qi-down-and-inst">
+ <section xml:id="s4s-qi-down-and-inst">
   <title>Download and Installation Preparations</title>
 
   <procedure>
@@ -37,10 +43,10 @@
     </para>
    </step>
   </procedure>
- </sect1>
+ </section>
 
  <!-- ================================================================== -->
- <sect1>
+ <section>
   <title>Hardware Requirements</title>
 
   <variablelist>
@@ -60,10 +66,10 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 
  <!-- ================================================================== -->
- <sect1 id="s4s-qi-inst">
+ <section xml:id="s4s-qi-inst">
   <title>Installation</title>
 
   <procedure>
@@ -132,8 +138,7 @@
     <para>
      Select <guimenu>SLES for SAP Applications &mdash; Installation with
      Wizard</guimenu> and press enter to start the semi-automated
-     installation procedure.  For details and caveats, see <xref
-     linkend="s4s-inst-wizard"/>.
+     installation procedure.  For details and caveats, see <xref linkend="s4s-inst-wizard"/>.
     </para>
    </step>
 
@@ -161,7 +166,7 @@
   </procedure>
 
  <!-- ================================================================== -->
- <sect2 id="s4s-qi-inst-s4s-basic">
+ <section xml:id="s4s-qi-inst-s4s-basic">
   <title>Installation of &sles4sap;</title>
 
    <para>
@@ -177,9 +182,9 @@ will provide some dialogs for basic system settings. The Media-Changer will not
 start for installation of a validated SAP solution.  If the Media-Changer
 should be used to install a validated SAP solution, it can be started manually
 from within &yast;.</para>
- </sect2>
+ </section>
  <!-- ================================================================== -->
- <sect2 id="s4s-qi-inst-s4s">
+ <section xml:id="s4s-qi-inst-s4s">
   <title>Installation of &sles4sap; with Wizard</title>
    
    <para>The normal &ay; driven SLES for SAP Applications installation
@@ -194,9 +199,9 @@ automatic system reboot (do not change the default "Boot from Hard Disk" in
 case you left the DVD inserted), you will be prompted to insert the SAP
 installation media; then follow the instructions.
 </para>
-  </sect2>
+  </section>
  <!-- ================================================================== -->
- <sect2 id="s4s-qi-inst-s4s-manual">
+ <section xml:id="s4s-qi-inst-s4s-manual">
   <title>Installation of &sles4sap; with External Profile</title>
 
    <para>
@@ -219,17 +224,17 @@ and configuration of &sles4sap;.</para>
    You can choose the SAP specific pattern, the HA, WebYaST components and SAP
    specific IBM Java as well in this installation scenario, but they are
    <emphasis>not</emphasis> preselected.</para>
-  </sect2>
+  </section>
  <!-- ================================================================== -->
- </sect1>
-<sect1>
+ </section>
+<section>
   <title>SAP Specific Instructions</title>
   
   <para>
    For further installation instructions and the SAP specific parts in
    particular, refer to the SAP Installation Guide (the
    <quote>Cookbook</quote>).</para>
- </sect1>
+ </section>
 
  <!-- This is duplicated info; comment it
  <sect1>
@@ -273,7 +278,7 @@ and configuration of &sles4sap;.</para>
  </sect1>
 -->
 
- <sect1>
+ <section>
   <title>How to Install with Installation Media from the Network</title>
   <procedure>
    <step>
@@ -298,10 +303,10 @@ and configuration of &sles4sap;.</para>
   <para>
     That is all you need for a network installation. If you want to avoid using
     a DVD to bootstrap the system and boot from the network via PXE, read the
-    documentation about setting up a PXE environment (<ulink url="http://www.suse.de/~ug/autoyast_doc/bootmedium.html"/>).</para>
- </sect1>
+    documentation about setting up a PXE environment (<link xlink:href="http://www.suse.de/~ug/autoyast_doc/bootmedium.html"/>).</para>
+ </section>
 
- <sect1>
+ <section>
   <title>Media Changer and Network Sources</title>
   <para>
 If you want to put your media on a NFS Server, proceed as follows:</para>
@@ -335,9 +340,8 @@ If you want to put your media on a NFS Server, proceed as follows:</para>
   <para>
     Now the media changer can also install from your NFS server.
  </para>
- </sect1>
-</chapter>
-<!-- ...
+ </section>
+</chapter><!-- ...
 "Finishing Basic Installation
 Reboot...
 ...


### PR DESCRIPTION
This PR contains:

* Converted DocBook4 sources to DocBook5 with the [migration script](https://github.com/sknorr/daps-migrate-tools/blob/master/migrate2docbook5.sh)
* Adapted `STYLEROOT` in DC file.

Tested:

* Run `daps -d DC-SLES4SAP-guide validate` which was ok.
* Run `daps -v -d DC-SLES4SAP-guide pdf` which created a PDF; looked good.

