### PR TITLE
Add commands "delete" & "rename" for saptune

### DIFF
--- a/xml/s4s_tune.xml
+++ b/xml/s4s_tune.xml
@@ -564,6 +564,33 @@
    <para>All features of &saptune; are available.</para>
   </sect2>
 
+  <sect2 xml:id="sec-s4s-saptune-delete">
+   <title>Deleting a &sap; Note</title>
+   <para>
+    This command allows to delete a created note including the corresponding override
+    after confirmation:
+   </para>
+   <screen>&prompt.root;<command>saptune note delete</command></screen>
+   <para>
+    The note may not be applied at the time.
+    &sap; notes shipped by &saptune; cannot be deleted. Instead, the override
+    file is removed when available.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-s4s-saptune-rename">
+   <title>Renaming a &sap; Note</title>
+   <para>
+    This command allows to rename a created note including the corresponding override
+    after confirmation:
+   </para>
+   <screen>&prompt.root;<command>saptune note rename</command></screen>
+   <para>
+    The note may not be applied at the time.
+    &sap; notes shipped by &saptune; cannot be renamed.
+   </para>
+  </sect2>
+
   <sect2 xml:id="sec-s4s-saptune-show">
    <title>Showing the Configuration of an &sap; Note</title>
    <para>


### PR DESCRIPTION
This PR fixes https://jira.suse.com/browse/PM-1346 and contains a description for:

* `saptune note delete`
* `saptune note rename`

Co-authored-by: Sören Schmidt <scmschmidt>

---

Screenshot:

![saptune-rm-and-mv](https://user-images.githubusercontent.com/1312925/74028120-e5af6800-49a9-11ea-9a4c-25047748e0b0.png)
