### PR TITLE
Fix outdated ClusterTools2 (jira#SLE-10758)

### DIFF
--- a/xml/s4s_components.xml
+++ b/xml/s4s_components.xml
@@ -469,7 +469,7 @@
     For more information, see the man page of the respective tool,
     included with the package <package>ClusterTools2</package>. Also see the
     project home page at
-    <link xlink:href="https://github.com/fmherschel/ClusterTools2"/>.
+    <link xlink:href="https://github.com/SUSE/cluster-tools.git"/>.
    </para>
   </sect3>
  </sect2>


### PR DESCRIPTION
This PR contains a fix for [SLE-10758](https://jira.suse.com/browse/SLE-10758):

* updated link to GitHub repo

I've checked the section (ID=sec-component-clustertool in file `s4s_components.xml`), but as the explanation was very general (no specific command lines) I didn't change anything there.