### PR TITLE
Removing support mentioning

### DIFF
--- a/xml/art_solution_monitoring.xml
+++ b/xml/art_solution_monitoring.xml
@@ -29,10 +29,6 @@ Further information:
          The solutions that is described here works for &slsreg;&nbsp;12
          SP3 to 15&nbsp;SP2.
        </para>
-       <para>
-         Keep in mind, the solution described here is not officially supported by &suse;.
-         It is based on best efforts and published <quote>as is</quote>.
-       </para>
      </abstract>
    </info>
 


### PR DESCRIPTION
The exporters are part of SLES for SAP and fully supported by SUSE.