### PR TITLE
Fix bsc#1179885: Distinguish sapconf versions

### DIFF
--- a/xml/s4s_tune.xml
+++ b/xml/s4s_tune.xml
@@ -636,7 +636,16 @@ vm.pagecache_limit_ignore_dirty = <replaceable>2</replaceable></screen>
      <para>
       To see which profile is currently in use:
      </para>
-     <screen>&prompt.root;<command>cat /var/lib/sapconf/act_profile</command></screen>
+     <itemizedlist>
+      <listitem>
+       <para>For &sapconf; 5.0.0:</para>
+       <screen>&prompt.root;<command>cat /var/lib/sapconf/act_profile</command></screen>
+      </listitem>
+      <listitem>
+       <para>From &sapconf; 5.0.1 and higher:</para>
+       <screen>&prompt.root;<command>cat /run/sapconf_act_profile</command></screen>
+      </listitem>
+     </itemizedlist>
     </listitem>
     <listitem> 
      <para>


### PR DESCRIPTION
This PR contains:

Distinguishes between different sapconf versions:

* Use /var/lib/sapconf/act_profile for sapconf 5.0.0
* Use /run/sapconf_act_profile for sapconf >= 5.0.1

Related to [bsc#1179885](https://bugzilla.suse.com/show_bug.cgi?id=1179885).