### PR TITLE
Improve note and GitHub links

### DIFF
--- a/xml/art_solution_automation.xml
+++ b/xml/art_solution_automation.xml
@@ -32,15 +32,21 @@ https://confluence.suse.com/x/8IEnGw
   <note>
     <title>About Official &suse; Support</title>
     <para>
-      The referenced &salt; formulas install and configure &sles4sapreg; including
-      advanced configurations like &hana; System Replication setup and configure 
-      the &ha; cluster. The &salt; formulas are part of &sles4sapreg; and fully supported 
-      by &suse;.
-      The other parts that belong to the infrastructure (like machines, network,
-      disk formats, mount points) need to be done with &suma;, &ay;,
-      or &terraform;. Keep in mind, our &terraform; project is currently published
-      <emphasis>as-is</emphasis> and supported by the open-source community.
-      For more information, see <link
+       The referenced &salt; formulas install and configure SAP software
+       (&hana;, &netweaver;, and &s4h;) on &productname; including
+       advanced configurations like &hana; System Replication setup and
+       configure the &ha; cluster.
+       The &salt; formulas are part of  &sles4sapreg;, provided via the
+       official repositories and are fully supported by &suse;.
+     </para>
+    <para>
+      &suse; works in the overall project on additional parts that cover
+      infrastructure aspects (like machines, network, disk formats, mount
+      points) that need to be performed with &suma;, &ay;, or Terraform
+      and are not shipped as part of &productname;.
+      These parts of the project available via &suse; GitHub repositories are
+      published as-is and supported by the open-source community. For more
+      information, see <link
         xlink:href="https://github.com/SUSE/ha-sap-terraform-deployments"/>.
     </para>
   </note>

--- a/xml/art_solution_automation.xml
+++ b/xml/art_solution_automation.xml
@@ -45,7 +45,7 @@ https://confluence.suse.com/x/8IEnGw
       points) that need to be performed with &suma;, &ay;, or Terraform
       and are not shipped as part of &productname;.
       These parts of the project available via &suse; GitHub repositories are
-      published as-is and supported by the open-source community. For more
+      published as-is and supported by the open source community. For more
       information, see <link
         xlink:href="https://github.com/SUSE/ha-sap-terraform-deployments"/>.
     </para>
@@ -335,10 +335,6 @@ https://confluence.suse.com/x/8IEnGw
       Use the &salt; formula <package>saphanabootstrap-formula</package> for bootstrapping
       and managing &hana; platform and system replication.
     </para>
-    <formalpara>
-      <title>Link:</title>
-      <para><link xlink:href="https://github.com/SUSE/saphanabootstrap-formula"/>.</para>
-    </formalpara>
     <para>The &salt; formula takes care of the following</para>
     <itemizedlist>
       <listitem>
@@ -445,10 +441,6 @@ https://confluence.suse.com/x/8IEnGw
       Use the &salt; formula <package>sapnwbootstrap-formula</package> for bootstrapping
       and managing the &netweaver; platform.
     </para>
-    <formalpara>
-      <title>Link:</title>
-      <para><link xlink:href="https://github.com/SUSE/sapnwbootstrap-formula"/>.</para>
-    </formalpara>
     <note>
       <para>The formula works only with &hana; as database.</para>
     </note>
@@ -519,10 +511,6 @@ https://confluence.suse.com/x/8IEnGw
       Use the &salt; formula <package>habootstrap-formula</package> for bootstrapping and managing
       a high availability cluster with the &crmshell;.
     </para>
-    <formalpara>
-      <title>Link:</title>
-      <para><link xlink:href="https://github.com/SUSE/habootstrap-formula"/>.</para>
-    </formalpara>
     <itemizedlist>
       <title>Properties for <package>habootstrap-formula</package></title>
       <listitem>
@@ -558,14 +546,6 @@ https://confluence.suse.com/x/8IEnGw
       Use the &salt; formula <package>habootstrap-formula</package> for bootstrapping and managing
       a high availability cluster with the &crmshell;.
     </para>
-    <formalpara>
-      <title>Link:</title>
-      <para><link xlink:href="https://github.com/SUSE/drbd-formula"/>.</para>
-    </formalpara>
-    <formalpara>
-      <title>Link:</title>
-      <para><link xlink:href="https://github.com/SUSE/habootstrap-formula"/>.</para>
-    </formalpara>
     <example>
       <title>Installation</title>
       <!-- old: obs://network:ha-clustering:sap-deployments:devel -->
@@ -601,6 +581,44 @@ https://confluence.suse.com/x/8IEnGw
           >High availability of &hana; on Azure VMs on &sls;</link></para>
       </listitem>
     </itemizedlist>
+    <para>
+      The open source repositories of the deployment automation can be found
+      at the following GitHub repositories, including the Terraform
+      scripts. All scripts provided in the repositories are as-is and are
+      not supported as part of &sles4sap;.
+    </para>
+    <variablelist>
+      <varlistentry>
+        <term>&hana; deployment automation</term>
+        <listitem>
+          <para><link xlink:href="https://github.com/SUSE/saphanabootstrap-formula"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>&netweaver; automated configuration</term>
+        <listitem>
+          <para><link xlink:href="https://github.com/SUSE/sapnwbootstrap-formula"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>&ha; cluster automated configuration</term>
+        <listitem>
+          <para><link xlink:href="https://github.com/SUSE/habootstrap-formula"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>&ha; cluster automated configuration (DRBD)</term>
+        <listitem>
+          <para><link xlink:href="https://github.com/SUSE/drbd-formula"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>&ha; cluster automated configuration (&salt;)</term>
+        <listitem>
+          <para><link xlink:href="https://github.com/SUSE/habootstrap-formula"/></para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </sect1>
 
   <xi:include href="common_copyright_quick.xml"/>


### PR DESCRIPTION
This PR contains the following changes:

* Rephrase note text about official support
* Move GitHub links into "For more information" section

Once all is confirmed, cherry-pick into:

* [ ] maintenance/15_GA
* [ ] maintenance/15_SP1
* [ ] maintenance/15_SP2

----


![box](https://user-images.githubusercontent.com/1312925/102085347-caf21f00-3e16-11eb-96ce-568fba66bcc3.png)

![list](https://user-images.githubusercontent.com/1312925/102085391-dba29500-3e16-11eb-97c5-242f5d3b4c11.png)

