### PR TITLE
Fix typo, thanks to Peter Varkoly

### DIFF
--- a/xml/s4s_clamsap.xml
+++ b/xml/s4s_clamsap.xml
@@ -214,7 +214,7 @@ Active: active (running) since Tue 2017-04-11 10:33:03 UTC; 24h ago
      </listitem>
      <listitem>
       <para>
-       <guimenu>Adapter Path</guimenu>: <filename>libclamsap.so</filename>
+       <guimenu>Adapter Path</guimenu>: <filename>libclamdsap.so</filename>
       </para>
      </listitem>
     </itemizedlist>


### PR DESCRIPTION
Found by Peter Varkoly. Many thanks! :+1: 

This PR contains:

* a typo fix

TODO:

* fix `images/src/jpg/sap-nw-scanner-definition-add.jpg`

Addition:

* Needs to be applied to SLE 12 SP2 an onwards