### PR TITLE
Fix bsc#1182953: correct wrong SAP note

### DIFF
--- a/xml/s4s_partitioning.xml
+++ b/xml/s4s_partitioning.xml
@@ -48,9 +48,9 @@
    <listitem>
     <para>
      <filename>/dev/system/swap</filename>: by default 2 GB, avoid setting a
-     smaller size.  See also <citetitle>SAP Note 1984787: SUSE Linux Enterprise
-     Server 12: Installation notes</citetitle>
-     (<link xlink:href="&sapnoteaddress;1984787"/>).
+     smaller size.  See also <citetitle>SAP Note 2578899: SUSE Linux Enterprise
+     Server 15: Installation notes</citetitle>
+     (<link xlink:href="&sapnoteaddress;2578899"/>).
     </para>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
Use SAP note 2578899 instead of 1984787.

Cherry-pick it to:

* `maintenance/15_GA`: 
* `maintenance/15_SP1`: 
* `maintenance/15_SP2`: 