### PR TITLE
Remove sapstartsrv and use sapstart

### DIFF
--- a/xml/s4s_tune_wmp.xml
+++ b/xml/s4s_tune_wmp.xml
@@ -77,13 +77,13 @@
                 <term>&sap; start service</term>
                 <listitem>
                     <para>
-                        The SAP Start Service (<systemitem>sapstartsrv</systemitem>)
+                        The SAP Start Service
                         manages the start and stop of &sap; instances. An important
-                        feature for  WMP is the configurable execution of programs
+                        feature for WMP is the configurable execution of programs
                         before the instance itself gets started in the instance profile.
                         WMP uses this method to call a program to move the
-                        <systemitem>sapstartsrv</systemitem>/<systemitem>sapstart</systemitem>
-                        processes into a designated cgroup, so the &sap; instance will
+                        <systemitem>sapstart</systemitem>
+                        process into a designated cgroup, so the &sap; instance will
                         be started inside that cgroup.
                     </para>
                 </listitem>
@@ -395,7 +395,7 @@ Directory /sys/fs/cgroup/SAP.slice:
 | |-3624 dw.sapHA0_D01 pf=/usr/sap/HA0/SYS/profile/HA0_D01_sapha0ci
 ...</screen>
                     <para>
-                        The <systemitem>sapstartsrv</systemitem> process of an instance
+                        The <systemitem>sapstart</systemitem> process of an instance
                         remains always in the user slice of
                         <literal><replaceable>SID</replaceable>adm</literal>.
                         Only the <systemitem class="process">sapstart</systemitem> process
@@ -634,7 +634,7 @@ ha0adm    3133 0::/SAP.slice/wmp-r73c594e050904c9c922a312dd9a28fd4.scope    ms.s
 ha0adm    3134 0::/SAP.slice/wmp-r73c594e050904c9c922a312dd9a28fd4.scope    en.sapHA0_ASCS00 pf=/usr/sap/HA0/SYS/profile/HA0_ASCS00_sapha0as
 ha0adm    3327 0::/SAP.slice/wmp-ra42489517eb846c282c57681e627a496.scope    sapstart pf=/usr/sap/HA0/ERS10/profile/HA0_ERS10_sapha0er
 ...</screen>
-        <para>All instance processes except <systemitem>sapstartsrv</systemitem> have to be in a scope below
+        <para>All instance processes except <systemitem>sapstart</systemitem> have to be in a scope below
             <systemitem>0::/SAP.slice/</systemitem>.</para>
         <para>
             To verify the correct setup, use the <command>wmp_check</command> tool.


### PR DESCRIPTION
sapstartsrv is no longer moved to SAP.slice

@scmschmidt: Could you have a look? I also found the `sapstartsrv` string in the same file, but in a different line. I also replaced them with `sapstart`. However, I'm not sure if this was correct so I changed that so you can see them in the diff.

With this commit, I couldn't find any further `sapstartsrv` strings in other files.
