### PR TITLE
Fix URLs

### DIFF
--- a/xml/art_solution_automation.xml
+++ b/xml/art_solution_automation.xml
@@ -540,7 +540,7 @@ https://confluence.suse.com/x/8IEnGw
     <para>
       Use the formula <package>drbd-formula</package> for setting up and managing
       DRBD devices with the command <command>drbdadm</command>.
-      Find more information in <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/cha-ha-drbd.html"/>.
+      Find more information in <link xlink:href="https://documentation.suse.com/sle-ha/html/SLE-HA-all/cha-ha-drbd.html"/>.
     </para>
     <para>
       Use the &salt; formula <package>habootstrap-formula</package> for bootstrapping and managing

--- a/xml/art_solution_automation.xml
+++ b/xml/art_solution_automation.xml
@@ -540,7 +540,7 @@ https://confluence.suse.com/x/8IEnGw
     <para>
       Use the formula <package>drbd-formula</package> for setting up and managing
       DRBD devices with the command <command>drbdadm</command>.
-      Find more information in <link xlink:href="https://documentation.suse.com/sle-ha/html/SLE-HA-all/cha-ha-drbd.html"/>.
+      Find more information in <link xlink:href="https://documentation.suse.com/sle-ha-15/html/SLE-HA-all/cha-ha-drbd.html"/>.
     </para>
     <para>
       Use the &salt; formula <package>habootstrap-formula</package> for bootstrapping and managing

--- a/xml/s4s_about.xml
+++ b/xml/s4s_about.xml
@@ -202,7 +202,7 @@
   <para>
    For information about all modules and extensions available for the &sle;
    product line, see
-   <link xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/art-modules.html"/>.
+   <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/art-modules.html"/>.
   </para>
   <para condition="noquick">
    For more information about &ph;, see <xref linkend="sec-packagehub"/>.

--- a/xml/s4s_about.xml
+++ b/xml/s4s_about.xml
@@ -202,7 +202,7 @@
   <para>
    For information about all modules and extensions available for the &sle;
    product line, see
-   <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/art-modules.html"/>.
+   <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/art-modules.html"/>.
   </para>
   <para condition="noquick">
    For more information about &ph;, see <xref linkend="sec-packagehub"/>.

--- a/xml/s4s_components.xml
+++ b/xml/s4s_components.xml
@@ -383,7 +383,7 @@
    </itemizedlist>
    <para>
     For more information, see the encryption chapter in the Security Guide,
-    <link xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/book-security.html"/>
+    <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-security.html"/>
    </para>    
    </sect3> -->
 

--- a/xml/s4s_components.xml
+++ b/xml/s4s_components.xml
@@ -383,7 +383,7 @@
    </itemizedlist>
    <para>
     For more information, see the encryption chapter in the Security Guide,
-    <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-security.html"/>
+    <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/book-security.html"/>
    </para>    
    </sect3> -->
 

--- a/xml/s4s_tune_wmp.xml
+++ b/xml/s4s_tune_wmp.xml
@@ -34,7 +34,7 @@
     </para>
     <para>
         For more information about cgroups, see
-        <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-tuning-cgroups.html"
+        <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/cha-tuning-cgroups.html"
         />.
     </para>
 

--- a/xml/s4s_tune_wmp.xml
+++ b/xml/s4s_tune_wmp.xml
@@ -34,7 +34,7 @@
     </para>
     <para>
         For more information about cgroups, see
-        <link xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-tuning-cgroups.html"
+        <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-tuning-cgroups.html"
         />.
     </para>
 


### PR DESCRIPTION
Remove SP-specific info from links to documentation.suse.com.