### PR TITLE
Use "Intel 64" as supported CPU

### DIFF
--- a/xml/s4s_planning.xml
+++ b/xml/s4s_planning.xml
@@ -26,7 +26,7 @@
     <term>Supported CPU</term>
     <listitem>
      <para>
-      &x86-64;
+      &intel64;
      </para>
      <para>
       IBM &power;&nbsp;8 (with PowerVM)


### PR DESCRIPTION
This PR fixes [bsc#1188243](https://bugzilla.suse.com/show_bug.cgi?id=1188243)

Only Intel 64 is supported. Neither Intel ia64 nor AMD64 are supported by SAP for HANA.

Needed for:

* `maintenance/15_SP3`
* `maintenance/15_SP2`
* `maintenance/15_SP1`
* `maintenance/15_GA`
* `maintenance/12_SP5`
* `maintenance/12_SP4`
* `maintenance/12_SP3`