### PR TITLE
Add admon for ClamSAP max file size (DOCTEAM#357)

### DIFF
--- a/xml/s4s_clamsap.xml
+++ b/xml/s4s_clamsap.xml
@@ -16,6 +16,44 @@
    The version of &clamsap; shipped with &productname;
    &productnumber; supports NW-VSI version 2.0.
   </para>
+ <important>
+  <title>Avoid false positive reports for large files exeeding maximum file size</title>
+  <remark>toms 2021-10-20: See https://www.suse.com/support/kb/doc/?id=000020324</remark>
+  <para> By default, &clamav; is not scanning files exeeding various limits like
+   file sizes, nesting level, or scan time. Such files are reported as "OK". The
+   current default settings for the &clamav; virus scan engine in the
+    <command>clamscan</command> commandline tool and the <systemitem
+    class="daemon">clamd</systemitem> scan daemon are set in a way that: </para>
+  <itemizedlist>
+   <listitem>
+    <para>Files and archives are scanned, but only up to the configured or default limits
+     for size, nesting level, scan time, etc.</para>
+   </listitem>
+   <listitem>
+    <para>
+     The scan engine reports these files as being "OK".
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     This could potentially allow attackers to bypass the virus scanning.
+    </para>
+   </listitem>
+  </itemizedlist>
+  <para> Alerts can be enabled to set the
+    <option>--alert-exceeds-max=yes</option> option on the
+    <command>clamscan</command> commandline or via <option>AlertExceedsMax
+    TRUE</option> in <filename>clamd.conf</filename> for daemon based scans.
+   Settings these options will cause a "FOUND" report of status type
+    <literal>Heuristics.Limits.Exceeded</literal>. You need to handle such
+   files differently in front-ends or processing of reports.
+  </para>
+  <para>
+   Before enabling the alert, ensure that front-ends will not suddenly
+   quarantine or remove those files.
+  </para>
+ </important>
+
  <sect1 xml:id="sec-clamsap-install">
   <title>Installing &clamsap;</title>
   <procedure>


### PR DESCRIPTION
This PR fixes `DOCTEAM#357`.

Files that are bigger than the max file size limit are not going to be fully scanned. No alert will bring attention to that file.

Potential attackers can bypass the virus scanning. The admon included describes the current state and how to avoid this.

Based on https://www.suse.com/support/kb/doc/?id=000020324

Needs backports for:

* SUSE Linux Enterprise Server 15 for SAP GA - SP3
  * `maintenance/15_SP3`: 2a134aa2a4
  * `maintenance/15_SP2`: b9929d1b9
  * `maintenance/15_SP1`: cf3fb07
  * `maintenance/15_GA`: 3cb3d18
* SUSE Linux Enterprise Server 12SP3 - SP5
  * `maintenance/12_SP5`: 5e8f70f
  * `maintenance/12_SP4`: 660817c
  * `maintenance/12_SP3`: d86e4cb

