### PR TITLE
SEO: edit urls removed l10n SLESforSAP 15SP3

### DIFF
--- a/l10n/ja-jp/guide/xml/MAIN-SLES4SAP-guide.xml
+++ b/l10n/ja-jp/guide/xml/MAIN-SLES4SAP-guide.xml
@@ -20,7 +20,6 @@
       <dm:product>SUSE Linux Enterprise Server for SAP Applications 15 SP3</dm:product>
       <dm:assignee>thomas.schraitle@suse.com</dm:assignee>
     </dm:bugtracker>
-    <dm:editurl>https://github.com/SUSE/doc-slesforsap/blob/main/xml/</dm:editurl>
     <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_copyright_gfdl.xml" parse="xml"/>

--- a/l10n/ja-jp/quick/xml/MAIN-SLES4SAP-guide.xml
+++ b/l10n/ja-jp/quick/xml/MAIN-SLES4SAP-guide.xml
@@ -20,7 +20,6 @@
       <dm:product>SUSE Linux Enterprise Server for SAP Applications 15 SP3</dm:product>
       <dm:assignee>thomas.schraitle@suse.com</dm:assignee>
     </dm:bugtracker>
-    <dm:editurl>https://github.com/SUSE/doc-slesforsap/blob/main/xml/</dm:editurl>
     <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_copyright_gfdl.xml" parse="xml"/>


### PR DESCRIPTION
dm:editurls tag removed for all languages of SLE 15 SP3.

Will be done for each branch version separately therefore no backports needed.