### PR TITLE
SEO: reset dm:component SLESforSAP 15 SP3

### DIFF
--- a/l10n/ja-jp/guide/xml/MAIN-SLES4SAP-guide.xml
+++ b/l10n/ja-jp/guide/xml/MAIN-SLES4SAP-guide.xml
@@ -16,7 +16,7 @@
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
     <dm:bugtracker>
       <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-      <dm:component>マニュアル</dm:component>
+      <dm:component>Documentation</dm:component>
       <dm:product>SUSE Linux Enterprise Server for SAP Applications 15 SP3</dm:product>
       <dm:assignee>thomas.schraitle@suse.com</dm:assignee>
     </dm:bugtracker>

--- a/l10n/ja-jp/quick/xml/MAIN-SLES4SAP-guide.xml
+++ b/l10n/ja-jp/quick/xml/MAIN-SLES4SAP-guide.xml
@@ -16,7 +16,7 @@
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
     <dm:bugtracker>
       <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-      <dm:component>マニュアル</dm:component>
+      <dm:component>Documentation</dm:component>
       <dm:product>SUSE Linux Enterprise Server for SAP Applications 15 SP3</dm:product>
       <dm:assignee>thomas.schraitle@suse.com</dm:assignee>
     </dm:bugtracker>


### PR DESCRIPTION
reset dm:component to "Documentation" 15 SP3 for all languages

will be done for each  version branch so no backport needed