### PR TITLE
remove edit urls l10n SLESforSAP15SP2

### DIFF
--- a/l10n/ja-jp/guide/xml/MAIN-SLES4SAP-guide.xml
+++ b/l10n/ja-jp/guide/xml/MAIN-SLES4SAP-guide.xml
@@ -20,7 +20,6 @@
       <dm:product>SUSE Linux Enterprise Server for SAP Applications 15 SP2</dm:product>
       <dm:assignee>thomas.schraitle@suse.com</dm:assignee>
     </dm:bugtracker>
-    <dm:editurl>https://github.com/SUSE/doc-slesforsap/edit/maintenance/15_SP2/xml/</dm:editurl>
     <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_copyright_gfdl.xml" parse="xml"/>

--- a/l10n/ja-jp/quick/xml/MAIN-SLES4SAP-guide.xml
+++ b/l10n/ja-jp/quick/xml/MAIN-SLES4SAP-guide.xml
@@ -20,7 +20,6 @@
       <dm:product>SUSE Linux Enterprise Server for SAP Applications 15 SP2</dm:product>
       <dm:assignee>thomas.schraitle@suse.com</dm:assignee>
     </dm:bugtracker>
-    <dm:editurl>https://github.com/SUSE/doc-slesforsap/edit/maintenance/15_SP2/xml/</dm:editurl>
     <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_copyright_gfdl.xml" parse="xml"/>


### PR DESCRIPTION
dm:editurls tag removed for all languages of SLES for SAP 15 SP2.

Will be done for each branch version separately therefore no backports needed