### PR TITLE
Fix bsc#1190426: Rename pattern name

### DIFF
--- a/xml/s4s_installation.xml
+++ b/xml/s4s_installation.xml
@@ -755,7 +755,7 @@
     To install the default package selection, use:
    </para>
     <screen>
-&prompt.root;<command>zypper in patterns-sles-sap_server</command>
+&prompt.root;<command>zypper in patterns-server-enterprise-sap_server</command>
     </screen>
   </important>
  </sect1>


### PR DESCRIPTION
Pattern name `patterns-sles-sap_server` was renamed to `patterns-server-enterprise-sap_server`

Thanks to Bernd Schubert!