### PR TITLE
Fix bsc#1191537: add pre-requisites for update wizard

### DIFF
--- a/xml/s4s_upgrade_sap_hana_cluster.xml
+++ b/xml/s4s_upgrade_sap_hana_cluster.xml
@@ -50,6 +50,11 @@
  <sect1 xml:id="sec-upgrade-sap-hana-cluster-preparing">
   <title>Preparing the upgrade</title>
   <procedure>
+   <para>
+    Ensure passwordless SSH access between the two nodes (primary and secondary) for &rootuser;.
+    Keep in mind, some cloud service providers might not have set up SSH access
+    for the &rootuser; by default.
+   </para>
    <step>
     <para>
      Install the <package>yast2-hana-update</package> package on both nodes:


### PR DESCRIPTION
This PR contains:

* a new step to ensure passwordless SSH access

Reference: [bsc#1191537](https://bugzilla.suse.com/show_bug.cgi?id=1191537)