### PR TITLE
Make clear when to use trento-premium package

### DIFF
--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -295,6 +295,16 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
     </itemizedlist>
 
     <para>
+      &t.server; premium is delivered as a Helm chart in order to facilitate its
+      installation process. If you already have a &k8s; cluster in place and
+      want to use it to run &t.server;, all you have to do is to install Helm
+      (<xref linkend="st-install-helm"/>) and then run command in <xref linkend="st-install-helm"/>
+      to deploy the helm chart in your &k8s; cluster.
+      If you don't have a &k8s; cluster or have one but don't want to use it for
+      Trento, you can deploy a small VM (see section 3.1 for minimum requirements
+      and follow steps 1 through 7 to get &t.server; up and running.
+    </para>
+    <para>
       The &t.server; is available as package <package>trento-premium</package> in your
       respective &suse; repository. The package does not require &productname;.
       This package is available for customers that do not have a K3s; in place and
@@ -302,10 +312,15 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
     </para>
 
     <para>
-      If you cannot or do not want to install the <package>trento-premium</package>
-      package, install Trento on your &t.server; host as follows: </para>
+      The <package>trento-premium-server-installer</package> package
+      simplifies the installation and installs K3s and Helm for you.
+      It replaces the following manual steps.
+      In case you want to install Trento on your &t.server; host manually,
+      proceed as follows:
+    </para>
 
-    <procedure>
+    <procedure xml:id="pro-trento-manually-installing">
+      <title>Manually installing Trento on a &t.server; host</title>
       <step>
         <para> Log on the &t.server; host.
         </para>
@@ -323,7 +338,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
           </step>
         </stepalternatives>
       </step>
-      <step>
+      <step xml:id="st-install-helm">
         <para>Install Helm as &rootuser;:</para>
         <screen>&prompt.root;curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash</screen>
       </step>
@@ -333,7 +348,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         </para>
         <screen>export KUBECONFIG=/etc/rancher/k3s/k3s.yaml</screen>
       </step>
-      <step>
+      <step xml:id="st-deploy-k3s">
         <para>
           With the same user that installed K3s, install the &t.server; container
           using Helm:

--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -299,10 +299,11 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
       installation process. If you already have a &k8s; cluster in place and
       want to use it to run &t.server;, all you have to do is to install Helm
       (<xref linkend="st-install-helm"/>) and then run command in <xref linkend="st-install-helm"/>
-      to deploy the helm chart in your &k8s; cluster.
+      to deploy the Helm chart in your &k8s; cluster.
       If you don't have a &k8s; cluster or have one but don't want to use it for
-      Trento, you can deploy a small VM (see section 3.1 for minimum requirements
-      and follow steps 1 through 7 to get &t.server; up and running.
+      Trento, you can deploy a small VM (see section <xref linkend="sec-trento-server-requirements"/>
+      for minimum requirements and follow steps in <xref linkend="pro-trento-manually-installing"/>
+      to get &t.server; up and running.
     </para>
 
     <para>

--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -304,12 +304,6 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
       Trento, you can deploy a small VM (see section 3.1 for minimum requirements
       and follow steps 1 through 7 to get &t.server; up and running.
     </para>
-    <para>
-      The &t.server; is available as package <package>trento-premium</package> in your
-      respective &suse; repository. The package does not require &productname;.
-      This package is available for customers that do not have a K3s; in place and
-      want to deploy the server on K3s for &productname;.
-    </para>
 
     <para>
       The <package>trento-premium-server-installer</package> package

--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -293,7 +293,17 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         </para>
       </listitem>
     </itemizedlist>
-    <para> To install Trento on your &t.server; host proceed as follows: </para>
+
+    <para>
+      The &t.server; is available as package <package>trento-premium</package> in your
+      respective &suse; repository. The package does not require &productname;.
+      This package is available for customers that do not have a K3s; in place and
+      want to deploy the server on K3s for &productname;.
+    </para>
+
+    <para>
+      If you cannot or do not want to install the <package>trento-premium</package>
+      package, install Trento on your &t.server; host as follows: </para>
 
     <procedure>
       <step>


### PR DESCRIPTION
The Trento premium installation package is available for customer that don't have a Kubernetes in place and want to deploy it on K3s on SLES for SAP.

---

![Screenshot 2022-03-02 at 13-51-49 Getting started with Trento Premium](https://user-images.githubusercontent.com/1312925/156365235-c277060d-4f37-4939-8cc1-c3082a974b07.png)

---

After the PR is merged, cherry-pick to `maintenance/15-SP3`.