### PR TITLE
Trento server 0.9.1

### DIFF
--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -331,7 +331,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         <screen>HELM_EXPERIMENTAL_OCI=1 helm upgrade \
    --install trento-server \
    oci://registry.suse.com/trento/trento-server \
-   --version 0.4.3 \
+   --version 0.4.4 \
    --set-file trento-runner.privateKey=<replaceable>PRIVATE_SSH_KEY</replaceable></screen>
       </step>
       <step>


### PR DESCRIPTION
Update Trento server installation instructions to use Trento server chart version 0.4.4, for the installation of Trento server 0.9.1