### PR TITLE
Introduce feedback option

### DIFF
--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -1130,8 +1130,8 @@ Warning: Permanently added '<replaceable>TRENTO_AGENT_IP</replaceable>' (ECDSA) 
   <section xml:id="sec-trento-feedback">
     <title>Giving feedback</title>
     <para>
-      On the right side of &t.server; page you will find the button <guimenu>Report feedback</guimenu>.
-      If you like to provide feedback to us, rate the page, send us what you liked and what can be improved.
+      On the right side of &t.server; console you will find the button <guimenu>Report feedback</guimenu>.
+      You can use it to provide feedback, rate the application, share what you liked and what can be improved.
       For enterprise support requests, use the <link xlink:href="&sccurl;">&scc;</link>.
     </para>
   </section>

--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -551,7 +551,7 @@ Warning: Permanently added '<replaceable>TRENTO_AGENT_IP</replaceable>' (ECDSA) 
     <section xml:id="sec-trento-web-home-page">
       <title>Home page</title>
       <para> The home page allows you to determine at a glance the Health Status of your &sap; environment. </para>
-      <figure>
+      <figure xml:id="fig-trento-web-home">
         <title>Hosts page</title>
         <mediaobject>
           <imageobject>
@@ -1126,7 +1126,16 @@ Warning: Permanently added '<replaceable>TRENTO_AGENT_IP</replaceable>' (ECDSA) 
       </step>
     </procedure>
   </section>
- 
+
+  <section xml:id="sec-trento-feedback">
+    <title>Giving feedback</title>
+    <para>
+      On the right side of &t.server; page you will find the button <guimenu>Report feedback</guimenu>.
+      If you like to provide feedback to us, rate the page, send us what you liked and what can be improved.
+      For enterprise support requests, use the <link xlink:href="&sccurl;">&scc;</link>.
+    </para>
+  </section>
+
   <section xml:id="sec-trento-more-information">
     <title>More information</title>
     <itemizedlist>


### PR DESCRIPTION
As discussed in our [2022-03-16 meeting](https://confluence.suse.com/display/TRNT/2022-03-16+Trento+Documentation),  this introduces a short explanation of the _Report feedback_ button on the Trento server home page.

I haven't inserted a screenshot (yet) as I wasn't sure if this would be stable the feedback form is.

---

![Screenshot 2022-03-30 at 10-13-49 Getting started with Trento Premium](https://user-images.githubusercontent.com/1312925/160784327-df8db583-e0b4-4793-8d90-cb71df0656da.png)

