### PR TITLE
Remove version flag

### DIFF
--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -351,7 +351,6 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         <screen>HELM_EXPERIMENTAL_OCI=1 helm upgrade \
    --install trento-server \
    oci://registry.suse.com/trento/trento-server \
-   --version 0.4.4 \
    --set-file trento-runner.privateKey=<replaceable>PRIVATE_SSH_KEY</replaceable></screen>
        <para>
           Note that the experimental flag is not needed as of Helm version 3.8.0.
@@ -1018,7 +1017,6 @@ Warning: Permanently added '<replaceable>TRENTO_AGENT_IP</replaceable>' (ECDSA) 
         <screen>HELM_EXPERIMENTAL_OCI=1 helm upgrade \
    --install trento-server \
    oci://registry.suse.com/trento/trento-server \
-   --version 0.4.4 \
    --set-file trento-runner.privateKey=<replaceable>PRIVATE_SSH_KEY</replaceable>
         </screen>
               <para>


### PR DESCRIPTION
Remove version flag from installation and update process of Trento Server (no longer needed).