### PR TITLE
Port required to reach Node Exporter

### DIFF
--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -250,6 +250,11 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
             &t.server; must be able to reach the &t.agent;s hosts via SSH (port TCP/22).
           </para>
         </listitem>
+         <listitem>
+          <para>
+            &t.server; must be able to reach the Node Exporter in the &t.agent;s hosts via (port TCP/9100).
+          </para>
+        </listitem>
         <listitem>
           <para>The &sap; administrator also needs access to &t.server; via HTTP (port TCP/80) or via HTTPS (port TCP/443) if SSL is enabled. </para>
         </listitem>

--- a/xml/article_sap_trento.xml
+++ b/xml/article_sap_trento.xml
@@ -252,7 +252,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         </listitem>
          <listitem>
           <para>
-            &t.server; must be able to reach the Node Exporter in the &t.agent;s hosts via (port TCP/9100).
+            &t.server; must be able to reach the Node Exporter in the &t.agent;s hosts (port TCP/9100).
           </para>
         </listitem>
         <listitem>


### PR DESCRIPTION
Adding port TCP/9100 as a network requirement