### PR TITLE
Introduce &productnameshort; entity

### DIFF
--- a/xml/MAIN-SLES4SAP-guide.xml
+++ b/xml/MAIN-SLES4SAP-guide.xml
@@ -11,7 +11,7 @@
  <title><phrase condition="noquick">Guide</phrase><phrase condition="quick">Installation Quick Start</phrase></title>
  <info>
   <productname>&productname;</productname>
-  <productname role="abbrev">&sles4sapa;</productname>
+  <productname role="abbrev">&productnameshort;</productname>
   <productnumber>&productnumber;</productnumber>
   <date><?dbtimestamp format="B d, Y"?></date>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/article_sap_automation.xml
+++ b/xml/article_sap_automation.xml
@@ -19,6 +19,7 @@ https://confluence.suse.com/x/8IEnGw
   <title>&sap; Automation</title>
   <subtitle>&sles4sapreg; · &slereg; &hasi;</subtitle>
   <info>
+    <productname role="abbrev">&productnameshort;</productname>
     <abstract>
       <para>
         This article offers some automation solutions for &sap; administrators.

--- a/xml/article_sap_automation.xml
+++ b/xml/article_sap_automation.xml
@@ -25,7 +25,7 @@ https://confluence.suse.com/x/8IEnGw
         This article offers some automation solutions for &sap; administrators.
         With &salt; formulas, it helps to efficiently configure &ha; and &sap; systems.
         The solutions that is described here works from &slsreg;&nbsp;12 SP3
-        and beyond. All packages are available in the &sles4sapa; module.
+        and beyond. All packages are available in the &productnameshort; module.
       </para>
     </abstract>
   </info>

--- a/xml/article_sap_monitoring.xml
+++ b/xml/article_sap_monitoring.xml
@@ -18,6 +18,7 @@ https://suse.com/c/coming-soon-sap-landscape-monitoring-on-sles-for-sap/
  <title>&sap; Monitoring</title>
  <subtitle>&sles4sapreg; · &sleha;</subtitle>
  <info>
+  <productname role="abbrev">&productnameshort;</productname>
   <abstract>
    <para>
     This article shows monitoring solutions for &sap; administrators to

--- a/xml/book_solution_based.xml
+++ b/xml/book_solution_based.xml
@@ -22,7 +22,7 @@ HINT (toms) 2020-06-05:
   <title>Solution-Based Documentation</title>
   <info>
     <productname>&productname;</productname>
-    <productname role="abbrev">&sles4sapa;</productname>
+    <productname role="abbrev">&productnameshort;</productname>
     <productnumber>&productnumber;</productnumber>
     <date><?dbtimestamp format="B d, Y"?></date>
     <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -3,6 +3,7 @@
 
 <!-- PRODUCT NAME AND VERSIONS -->
 <!ENTITY productname   "&s4s;">
+<!ENTITY productnameshort "&sles4sapa;">
 <!ENTITY product-ga    '15'>
 <!ENTITY product-sp    '5'>
 <!ENTITY productnumber '&product-ga; SP&product-sp;'>

--- a/xml/s4s_image.xml
+++ b/xml/s4s_image.xml
@@ -91,7 +91,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     On the &kiwi; configuration for &sles4sapa;, see
+     On the &kiwi; configuration for &productnameshort;, see
      <filename>/usr/share/kiwi/image/SLES4SAP/README</filename>.
     </para>
    </listitem>

--- a/xml/s4s_installation.xml
+++ b/xml/s4s_installation.xml
@@ -521,7 +521,7 @@
       Still FIXME for SP2. - sknorr, 2016-08-09
      </remark>
      <para>
-      The software firewall of &sles4sapa; is enabled by default.
+      The software firewall of &productnameshort; is enabled by default.
       However, often, the ports your &sap; product requires to be open
       are not opened automatically.
       This means that there may be network issues until you open the required
@@ -588,7 +588,7 @@
  </sect1>
 
  <sect1 condition="noquick" xml:id="sec-install-network">
-  <title>Using &sles4sapa; media from the network</title>
+  <title>Using &productnameshort; media from the network</title>
 
   <remark>
    FIXME: This section is not up-to-date SP2 does not ship with a sap.dud
@@ -598,7 +598,7 @@
   <para>
    This section provides a short description of how to install from an
    installation medium served over the network. This allows, for example,
-   using a regular &slsa; medium to install &sles4sapa;.
+   using a regular &slsa; medium to install &productnameshort;.
   </para>
 
   <procedure>


### PR DESCRIPTION
### Description

Introduce `&productnameshort;` entity as discussed in SLE Writers Call on 2022-11-21.

Dima, if you are okay with the change, I will take care of cherry-picking it into the different branches.

The first commit (0998779) introduces just the entity and adds it into the `<info>` element. The second commit (bd3b1f5) goes one step further and uses this newly introduced entity all over the document. I've separated the commits to make it (hopefully) easier to cherry-pick them.


### Are there any relevant issues/feature requests?

* DOCTEAM-828


### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
  - [x] 15 SP0
- SLES-SAP 12
  - [x] 12 SP5
  - [x] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
