### PR TITLE
Migration paths are not identical to SLES but to SLES with ESPOS (BSC…

### DIFF
--- a/xml/s4s_planning.xml
+++ b/xml/s4s_planning.xml
@@ -163,8 +163,10 @@
   <title>Offline migration</title>
 
   <para>
-   The migration paths for &sls; are identical to those for &sles4sap;. Find
-   detailed information in the &upgrade_guide; at
+   The migration paths for &sles4sap; are identical to those for &sls; with
+   <productname>Enhanced Service Pack Overlay Support</productname> (ESPOS).
+   Find detailed information in the <citetitle>&sls;</citetitle>
+   &upgrade_guide; at
    <link
    xlink:href="&dsc-sles;/html/SLES-all/cha-upgrade-paths.html"/>.
   </para>


### PR DESCRIPTION
…#1207062)

### Description

Clarify that the migration paths are identical to SLES with ESPOS, not just SLES.

This only addresses https://bugzilla.suse.com/show_bug.cgi?id=1207062, not yet https://bugzilla.suse.com/show_bug.cgi?id=1208489 or https://bugzilla.suse.com/show_bug.cgi?id=1209606

### Are there any relevant issues/feature requests?

*[ bsc#...](https://bugzilla.suse.com/show_bug.cgi?id=1207062)
* jsc#...


### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLES-SAP 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
