### PR TITLE
Fix grammar in s4s_upgrade_sap_hana_cluster.xml v2

### DIFF
--- a/xml/s4s_upgrade_sap_hana_cluster.xml
+++ b/xml/s4s_upgrade_sap_hana_cluster.xml
@@ -8,7 +8,7 @@
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Upgrading an &hana; cluster</title>
+ <title>Upgrading a &hana; cluster</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker/>
@@ -127,7 +127,7 @@
      The wizard shows you two steps: automatic and manual. In this automatic
      step, the wizard puts cluster resources into maintenance mode before it
      starts with the automatic steps. The manual steps are &hana; specific and
-     need to be executed by an &hana; administrator. For more information, see
+     need to be executed by a &hana; administrator. For more information, see
      the official &hana; documentation.
     </para>
    </step>


### PR DESCRIPTION
### Description

Change two instances of "... an &hana ..." to "... a &hana ..." so that it reads better - note previously submitted & fixed via #97

### Are there any relevant issues/feature requests?

N/A

### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [X] 15 next *(current `main`, no backport necessary)*
  - [X] 15 SP4
  - [X] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLES-SAP 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
