### PR TITLE
doc-kit run for 15 SP3 (fetch updates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 build/
 .vscode/
 .idea/
+*.code-workspace

--- a/doc-kit.conf
+++ b/doc-kit.conf
@@ -1,12 +1,13 @@
 type: docbook5-book
 variant: license-gfdl
 
-file: dc865ed00674536288a1e5a78ba07fe138aaabde  .gitignore
+file: 50fc57833230d2afd445ef11a36e81d2850993b1  .gitignore
 file: c6b4745307e90c9b88905b434cbbaddc54e4541b  .editorconfig
-file: 91adcbb744f5a87e9d707b3561a939b2c6638960  xml/generic-entities.ent
+file: 47e64cba1ddfdfa57fec4da6591e7259ac38afb5  xml/generic-entities.ent
 file: a79a3bc929478668955564bab48aecc8502555f6  xml/network-entities.ent
-file: 6f13c1c605e11c3499f9d18335e2bdadf6a0c73d  xml/common_intro_support.xml
-file: 678db25fa5a1f62232af7eb8db24fe409b4a11d5  xml/common_intro_convention.xml
+file: 877a69c29d30bd89aa36d79dd96c72dbde4a0ed8  xml/common_intro_available_doc.xml
+file: 2024e3be75c45cf26a2b076eee30c697a6e819a1  xml/common_intro_support.xml
+file: 578bc097d6cb4ef8aa08dbf4f1bf4400cae124f6  xml/common_intro_convention.xml
 file: fcb8648dbfbe5a036547347e2affbeb353622162  xml/common_intro_feedback.xml
 file: 1c8497ffe563b59832de4b0e106082aa4932a528  xml/common_copyright_gfdl.xml
 file: 7022e7485da1b892ea57faf858857981eb3644bc  xml/common_legal.xml

--- a/xml/common_intro_convention.xml
+++ b/xml/common_intro_convention.xml
@@ -49,7 +49,7 @@
   </listitem>
   <listitem>
    <para>
-    <systemitem class="username">user</systemitem>: The name of user or group
+    <systemitem class="username">user</systemitem>: The name of a user or group
    </para>
   </listitem>
   <listitem>
@@ -70,7 +70,7 @@
     As</guimenu> </menuchoice>: menu items, buttons
    </para>
   </listitem>
-  <listitem os="sles">
+  <listitem os="sles;slemicro">
    <para arch="x86_64">
     This paragraph is only relevant for the &x86-64; architectures. The
     arrows mark the beginning and the end of the text block.

--- a/xml/common_intro_support.xml
+++ b/xml/common_intro_support.xml
@@ -123,7 +123,7 @@
    to provide glimpses into upcoming innovations.
    Technology previews are included for your convenience to give you a chance
    to test new technologies within your environment.
-   We would appreciate your feedback!
+   We would appreciate your feedback.
    If you test a technology preview, please contact your &suse; representative
    and let them know about your experience and use cases.
    Your input is helpful for future development.
@@ -135,7 +135,7 @@
    <listitem>
     <para>
      Technology previews are still in development.
-     Therefore, they may be functionally incomplete, unstable, or in other ways
+     Therefore, they may be functionally incomplete, unstable, or otherwise
      <emphasis>not</emphasis> suitable for production use.
     </para>
    </listitem>
@@ -169,7 +169,7 @@
   </itemizedlist>
   <para>
    For an overview of technology previews shipped with your product, see the
-   release notes at <link xlink:href="&rn-url;"/>.
+   release notes at <link xlink:href="&sc-rn;"/>.
   </para>
  </sect2>
 </sect1>

--- a/xml/generic-entities.ent
+++ b/xml/generic-entities.ent
@@ -56,6 +56,8 @@
 
 <!-- SUSE PRODUCTS -->
 
+<!ENTITY sliberty               "&suse; Liberty Linux">
+
 <!-- SLE -->
 <!ENTITY jeos                   "JeOS"><!-- Just enough OS -->
 <!ENTITY jeosfirstboot          "&jeos; Firstboot">
@@ -77,6 +79,7 @@
 <!ENTITY slem                   "&sle; Micro">
 <!ENTITY bci                    "&slea; Base Container Image">
 <!ENTITY bcia                   "&slea; BCI">
+<!ENTITY dinstaller             "D-Installer">
 
 <!-- ALP -->
 <!ENTITY alp                    "Adaptable Linux Platform">
@@ -194,6 +197,7 @@ use &deng;! -->
 <!ENTITY rhel                   "&rh; Enterprise Linux">
 <!ENTITY rhla                   "RHEL">
 <!ENTITY rpios                  "Raspberry&nbsp;Pi&nbsp;OS">
+<!ENTITY centos                 "CentOS">
 
 
 
@@ -273,6 +277,8 @@ use &deng;! -->
 <!ENTITY chronyc                "<command xmlns='http://docbook.org/ns/docbook'>chronyc</command>">
 <!ENTITY debuginfod             "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>debuginfod</systemitem>">
 <!ENTITY gnome                  "GNOME">
+<!ENTITY gdm                    "&gnome; Display Manager">
+<!ENTITY gdmshort               "GDM">
 <!ENTITY grub                   "GRUB&nbsp;2">
 <!ENTITY grub-efi               "GRUB&nbsp;2 for EFI">
 <!ENTITY kdump                  "Kdump">
@@ -297,12 +303,14 @@ use &deng;! -->
 <!ENTITY rmtool                 "Repository Mirroring Tool">
 <!ENTITY salt                   "Salt">
 <!ENTITY samba                  "Samba">
+<!ENTITY scchvc                 "<command xmlns='http://docbook.org/ns/docbook'>scc-hypervisor-collector</command>">
 <!ENTITY selnx                  "SELinux">
 <!ENTITY smaster                "&salt; Master">
 <!ENTITY sminion                "&salt; Minion">
 <!ENTITY sudo                   "<command xmlns='http://docbook.org/ns/docbook'>sudo</command>">
 <!ENTITY suseconnect            "SUSEConnect">
 <!ENTITY tr-up                   "<command xmlns='http://docbook.org/ns/docbook'>transactional-update</command>">
+<!ENTITY tr-up-shell             "<command xmlns='http://docbook.org/ns/docbook'>transactional-update shell</command>">
 <!ENTITY xgeneric               "X Window System">
 <!ENTITY xvendor                "X.Org">
 <!ENTITY yast                   "YaST">
@@ -413,6 +421,7 @@ use &deng;! -->
 <!ENTITY rook                   "Rook">
 <!ENTITY grafana                "Grafana">
 <!ENTITY prometheus             "Prometheus">
+<!ENTITY fuelignition           "Fuel Ignition">
 
 
 
@@ -445,14 +454,27 @@ use &deng;! -->
 <!ENTITY ntp             "Network Time Protocol">
 
 
+<!-- Security -->
+<!ENTITY openscap               "OpenSCAP">
+<!ENTITY ssg                    "SCAP Security Guide">
+<!ENTITY pcidss                 "Payment Card Industry Data Security Standard">
+<!ENTITY pcidssa                "PCI DSS">
+<!ENTITY disa                   "Defense Information Systems Agency">
+<!ENTITY disaa                  "DISA">
+<!ENTITY stig                   "Security Technical Implementation Guide">
+<!ENTITY stiga                  "STIG">
+<!ENTITY stigviewer             "&disaa; &stiga; Viewer">
+<!ENTITY cis                    "Center for Internet Security">
+<!ENTITY cisa                   "CIS">
+<!ENTITY hipaa                  "Health Insurance Portability and Accountability Act">
+<!ENTITY hipaaa                 "HIPAA">
+<!ENTITY uefisecboot            "UEFI Secure Boot">
+
+
 <!-- MISCELLANEOUS -->
 
 <!ENTITY iscsi                  "iSCSI">
 <!ENTITY netteam                "Network Teaming">
-<!ENTITY openscap               "OpenSCAP">
-<!ENTITY pcidss                 "Payment Card Industry Data Security Standard">
-<!ENTITY pcidssa                "PCI DSS">
-<!ENTITY uefisecboot            "UEFI Secure Boot">
 
 
 
@@ -566,3 +588,4 @@ use &deng;! -->
 
 <!-- SLE, old guide names -->
 <!ENTITY sle_jeos_quick        "<citetitle xmlns='http://docbook.org/ns/docbook'>&jeos; Quick Start</citetitle>">
+<!ENTITY smtguide              "<citetitle xmlns='http://docbook.org/ns/docbook'>Subscription Management Tool Guide</citetitle>">


### PR DESCRIPTION
Updating the files provided by doc-kit to (mainly to include the latest updates for the common intro* files). As agreed with @dmpop, I skipped the doc-kit updates for common_intro_available_doc.xml as this has SLES-SAP specific content here.