### PR TITLE
Installation QS Guide: integrate proofing corrections

### DIFF
--- a/xml/s4s_about.xml
+++ b/xml/s4s_about.xml
@@ -238,7 +238,7 @@
      </para>
      <para>
       The last service pack of a &sles4sap; major release has a separate
-      lifecycle without ESPOS as there is no overlap to the next service pack.
+      lifecycle without ESPOS as there is no overlap with the next service pack.
       Instead, LTSS is offered for this last service pack at an additional cost.
      </para>
      <para>
@@ -287,7 +287,7 @@
   <important>
    <title>Lifecycle and Support for Modules and Extensions</title>
    <para>
-    Modules and extensions have a different lifecycle than &s4sa; and &suse;
+    Modules and extensions have a different lifecycle than &s4sa;, and &suse;
     provides different support offerings for them:
    </para>
    <itemizedlist>


### PR DESCRIPTION
### Description

Integrate proofing corrections for the Installation Quick Start Guide from proofing drop 3.

### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLES-SAP 12
  - [ ] 12 SP5
  - [ ] 12 SP4