### PR TITLE
SAP Guide: integrate proofing corrections

### DIFF
--- a/xml/common_intro_support.xml
+++ b/xml/common_intro_support.xml
@@ -88,7 +88,7 @@
    </listitem>
    <listitem>
     <para>
-     Sound, graphics, fonts, and artwork.
+     Sound, graphics, fonts and artwork.
     </para>
    </listitem>
    <listitem>

--- a/xml/s4s_about.xml
+++ b/xml/s4s_about.xml
@@ -238,7 +238,7 @@
      </para>
      <para>
       The last service pack of a &sles4sap; major release has a separate
-      lifecycle without ESPOS as there is no overlap to the next service pack.
+      lifecycle without ESPOS as there is no overlap with the next service pack.
       Instead, LTSS is offered for this last service pack at an additional cost.
      </para>
      <para>

--- a/xml/s4s_installation.xml
+++ b/xml/s4s_installation.xml
@@ -738,7 +738,7 @@
       only performs migration of repositories inside the operating system.
     </para>
     <para>
-      To perform migration, you must follow image migration guidelines by your
+      To perform migration, you must follow image migration guidelines with your
       cloud solution provider.
     </para>
     </warning>

--- a/xml/s4s_tune_wmp.xml
+++ b/xml/s4s_tune_wmp.xml
@@ -357,7 +357,7 @@ MemoryLow=18487889920    &lt;- Should be your chosen value (always in bytes)!
     </step>
     <step>
     <para>
-      Remove the lines calling <option>sapwmp-capture</option> from all instance profiles (for example: <command>Execute_20 = local /usr/lib/sapwmp/sapwmp-capture -a</command>. All &sap; services require restart after the change.
+      Remove the lines calling <option>sapwmp-capture</option> from all instance profiles (for example: <command>Execute_20 = local /usr/lib/sapwmp/sapwmp-capture -a</command>. All &sap; services require a restart after the change.
     </para>
     </step>
     <step>


### PR DESCRIPTION
### Description

Integrate proofing corrections for the SAP Guide from proofing drop 3.

### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLES-SAP 12
  - [ ] 12 SP5
  - [ ] 12 SP4
