### PR TITLE
available doc: latest doc-kit changes

### DIFF
--- a/xml/common_intro_available_doc.xml
+++ b/xml/common_intro_available_doc.xml
@@ -27,13 +27,13 @@
   This manual contains links to additional documentation resources that are
   either available on the system or online.
  </para>
- 
+
  <variablelist>
   <varlistentry>
    <term>Online documentation</term>
    <listitem condition="noquick">
     <para>
-     Visit 
+     Visit
      <link xlink:href="https://documentation.suse.com/#sles-sap"/> for the
      latest version of this guide in different formats. You can find whitepapers
      and other resources in the &sles4sap; resource library: &reslibrary;.
@@ -68,6 +68,17 @@
       version of the documentation.
      </para>
     </note>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>&suse; Knowledgebase</term>
+   <!--based on 'Support Resources' listed at https://www.suse.com/support/kb/-->
+   <listitem>
+    <para>
+     If you have run into an issue, also check out the Technical Information
+     Documents (TIDs) that are available online at <link xlink:href="https://www.suse.com/support/kb/"/>.
+     Search the &suse; Knowledgebase for known solutions driven by customer need.
+     </para>
    </listitem>
   </varlistentry>
   <varlistentry>


### PR DESCRIPTION
### Description

As doc-slesforsap uses its own `common_intro_available_doc.xml` file, propagate the latest changes for `common_intro_available_doc.xml` from doc-kit manually.

### Are there any relevant issues/feature requests?

-  see docbook5-book: enhance preface  openSUSE/doc-kit#88

### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [ ] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [ ] 15 SP1
- SLES-SAP 12
  - [x] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
