### PR TITLE
EOL SLES4SAP 15 SP1: Switch validation to DocBook 5.2

### DIFF
--- a/DC-SLES-SAP-sol-automation
+++ b/DC-SLES-SAP-sol-automation
@@ -5,3 +5,4 @@ PROFOS="sles"
 PROFCONDITION="noquick;suse-product"
 
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-SAP-sol-monitoring
+++ b/DC-SLES-SAP-sol-monitoring
@@ -5,3 +5,4 @@ PROFOS="sles"
 PROFCONDITION="noquick;suse-product"
 
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES4SAP-guide
+++ b/DC-SLES4SAP-guide
@@ -6,3 +6,4 @@ PROFCONDITION="noquick;suse-product"
 
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES4SAP-quick
+++ b/DC-SLES4SAP-quick
@@ -6,3 +6,4 @@ PROFCONDITION="quick;suse-product"
 
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"


### PR DESCRIPTION
### Description

This change switches the validation schema from GeekoDoc to DocBook 5.2. This ensures that futures changes of GeekoDoc doesn't affect previous, now unsupported documents.


### Are there any relevant issues/feature requests?

related to https://gitlab.suse.de/susedoc/docserv-config/-/merge_requests/510


### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [ ] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [x] 15 SP1
- SLES-SAP 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

no backport necessary
