### PR TITLE
adding basic metadata for portal testing

### DIFF
--- a/xml/MAIN-SLES4SAP-guide.xml
+++ b/xml/MAIN-SLES4SAP-guide.xml
@@ -7,13 +7,26 @@
 <?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
    type="text/xml"
    title="Profiling step"?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en" xml:id="book-s4s">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en" xml:id="book-s4s" xmlns:its="http://www.w3.org/2005/11/its">
  <title><phrase condition="noquick">Guide</phrase><phrase condition="quick">Installation Quick Start</phrase></title>
  <info>
   <productname>&productname;</productname>
   <productname role="abbrev">&productnameshort;</productname>
   <productnumber>&productnumber;</productnumber>
   <date><?dbtimestamp format="B d, Y"?></date>
+  <meta name="task" its:translate="no" condition="quick">
+    <phrase>Installation</phrase>
+    <phrase>Upgrade</phrase>
+  </meta>
+  <meta name="task" its:translate="no" condition="noquick">
+    <phrase>Installation</phrase>
+    <phrase>High Availability</phrase>
+    <phrase>Configuration</phrase>
+    <phrase>Clustering</phrase>
+    <phrase>Tuning</phrase>
+    <phrase>Security</phrase>
+  </meta>
+  <meta name="series" its:translate="no">Product Documentation</meta>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
     <dm:bugtracker>
       <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>

--- a/xml/article_sap_automation.xml
+++ b/xml/article_sap_automation.xml
@@ -15,11 +15,20 @@ https://confluence.suse.com/x/8IEnGw
 <article version="5.1" xml:lang="en" xml:id="article-sap-automation"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:its="http://www.w3.org/2005/11/its">
   <title>&sap; Automation</title>
   <subtitle>&sles4sapreg; · &slereg; &hasi;</subtitle>
   <info>
     <productname role="abbrev">&productnameshort;</productname>
+    <productnumber>&productnumber;</productnumber>
+    <date><?dbtimestamp format="B d, Y"?></date>
+    <meta name="task" its:translate="no">
+      <phrase>Automation</phrase>
+      <phrase>High Availability</phrase>
+      <phrase>Configuration</phrase>
+    </meta>
+    <meta name="series" its:translate="no">Product Documentation</meta>
     <abstract>
       <para>
         This article offers some automation solutions for &sap; administrators.

--- a/xml/article_sap_monitoring.xml
+++ b/xml/article_sap_monitoring.xml
@@ -14,11 +14,18 @@ https://suse.com/c/coming-soon-sap-landscape-monitoring-on-sles-for-sap/
 <article version="5.1" xml:lang="en" xml:id="article-sap-monitoring"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:its="http://www.w3.org/2005/11/its">
  <title>&sap; Monitoring</title>
  <subtitle>&sles4sapreg; · &sleha;</subtitle>
  <info>
   <productname role="abbrev">&productnameshort;</productname>
+  <productnumber>&productnumber;</productnumber>
+  <date><?dbtimestamp format="B d, Y"?></date>
+  <meta name="task" its:translate="no">
+    <phrase>Monitoring</phrase>
+  </meta>
+  <meta name="series" its:translate="no">Product Documentation</meta>
   <abstract>
    <para>
     This article shows monitoring solutions for &sap; administrators to


### PR DESCRIPTION
### Description

Add some basic metadata, so the tasks view and the filing of the docs as "Product Documentation" work. Currently just for main.


### Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [x ] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLES-SAP 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
