### PR TITLE
add final metadata for 15 SP5

### DIFF
--- a/xml/MAIN-SLES4SAP-guide.xml
+++ b/xml/MAIN-SLES4SAP-guide.xml
@@ -8,17 +8,23 @@
    type="text/xml"
    title="Profiling step"?>
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en" xml:id="book-s4s" xmlns:its="http://www.w3.org/2005/11/its">
- <title><phrase condition="noquick">Guide</phrase><phrase condition="quick">Installation Quick Start</phrase></title>
+ <title><phrase condition="noquick">Guide</phrase><phrase condition="quick">&instquick;</phrase></title>
  <info>
   <productname>&productname;</productname>
   <productname role="abbrev">&productnameshort;</productname>
   <productnumber>&productnumber;</productnumber>
+  <meta name="title" condition="quick" its:translate="yes">Installation Quick Start</meta>
+  <meta name="title" condition="noquick" its:translate="yes">Guide</meta>
+  <meta name="description" condition="quick" its:translate="yes">This document guides you through the installation of &productnameshort;.</meta>
+  <meta name="description" condition="noquick" its:translate="yes">This document provides detailed information about how to install and customize &productnameshort;.</meta>
+  <meta name="social-descr" condition="quick" its:translate="yes">A quick introduction to &productnameshort; installation.</meta>
+  <meta name="social-descr" condition="noquick" its:translate="yes">&productnameshort; installation and customization.</meta>
   <date><?dbtimestamp format="B d, Y"?></date>
-  <meta name="task" its:translate="no" condition="quick">
+  <meta name="task" its:translate="yes" condition="quick">
     <phrase>Installation</phrase>
     <phrase>Upgrade</phrase>
   </meta>
-  <meta name="task" its:translate="no" condition="noquick">
+  <meta name="task" its:translate="yes" condition="noquick">
     <phrase>Installation</phrase>
     <phrase>High Availability</phrase>
     <phrase>Configuration</phrase>

--- a/xml/MAIN-SLES4SAP-guide.xml
+++ b/xml/MAIN-SLES4SAP-guide.xml
@@ -20,6 +20,16 @@
   <meta name="social-descr" condition="quick" its:translate="yes">A quick introduction to &productnameshort; installation.</meta>
   <meta name="social-descr" condition="noquick" its:translate="yes">&productnameshort; installation and customization.</meta>
   <date><?dbtimestamp format="B d, Y"?></date>
+  <revhistory xml:id="rh-book-s4s">
+    <revision>
+      <date>2023-06-20</date>
+      <revdescription>
+        <para>
+          Updated for the initial release of &productname; &productnumber;.
+        </para>
+      </revdescription>
+    </revision>
+  </revhistory>
   <meta name="task" its:translate="yes" condition="quick">
     <phrase>Installation</phrase>
     <phrase>Upgrade</phrase>

--- a/xml/article_sap_automation.xml
+++ b/xml/article_sap_automation.xml
@@ -20,10 +20,14 @@ https://confluence.suse.com/x/8IEnGw
   <title>&sap; Automation</title>
   <subtitle>&sles4sapreg; · &slereg; &hasi;</subtitle>
   <info>
+    <productname>&productname;</productname>
     <productname role="abbrev">&productnameshort;</productname>
     <productnumber>&productnumber;</productnumber>
+    <meta name="title" its:translate="yes">&sap; Automation</meta>
+    <meta name="description" its:translate="yes">An introduction to automated solutions for &sap; administrators to efficiently configure &ha; and &sap; systems.</meta>
+    <meta name="social-descr" its:translate="yes">Automated solutions for &sap; administrators.</meta>
     <date><?dbtimestamp format="B d, Y"?></date>
-    <meta name="task" its:translate="no">
+    <meta name="task" its:translate="yes">
       <phrase>Automation</phrase>
       <phrase>High Availability</phrase>
       <phrase>Configuration</phrase>

--- a/xml/article_sap_automation.xml
+++ b/xml/article_sap_automation.xml
@@ -27,6 +27,16 @@ https://confluence.suse.com/x/8IEnGw
     <meta name="description" its:translate="yes">An introduction to automated solutions for &sap; administrators to efficiently configure &ha; and &sap; systems.</meta>
     <meta name="social-descr" its:translate="yes">Automated solutions for &sap; administrators.</meta>
     <date><?dbtimestamp format="B d, Y"?></date>
+    <revhistory xml:id="rh-article-sap-automation">
+      <revision>
+        <date>2023-06-20</date>
+        <revdescription>
+          <para>
+            Updated for the initial release of &productname; &productnumber;.
+          </para>
+        </revdescription>
+      </revision>
+    </revhistory>
     <meta name="task" its:translate="yes">
       <phrase>Automation</phrase>
       <phrase>High Availability</phrase>

--- a/xml/article_sap_monitoring.xml
+++ b/xml/article_sap_monitoring.xml
@@ -26,6 +26,16 @@ https://suse.com/c/coming-soon-sap-landscape-monitoring-on-sles-for-sap/
   <meta name="description" its:translate="yes">An introduction to monitoring solutions for &sap; administrators to efficiently monitor their &sap; systems.</meta>
   <meta name="social-descr" its:translate="yes">Monitoring solutions for &sap; administrators.</meta>
   <date><?dbtimestamp format="B d, Y"?></date>
+  <revhistory xml:id="rh-article-sap-monitoring">
+    <revision>
+      <date>2023-06-20</date>
+      <revdescription>
+        <para>
+          Updated for the initial release of &productname; &productnumber;.
+        </para>
+      </revdescription>
+    </revision>
+  </revhistory>
   <meta name="task" its:translate="yes">
     <phrase>Monitoring</phrase>
   </meta>

--- a/xml/article_sap_monitoring.xml
+++ b/xml/article_sap_monitoring.xml
@@ -19,10 +19,14 @@ https://suse.com/c/coming-soon-sap-landscape-monitoring-on-sles-for-sap/
  <title>&sap; Monitoring</title>
  <subtitle>&sles4sapreg; · &sleha;</subtitle>
  <info>
+  <productname>&productname;</productname>
   <productname role="abbrev">&productnameshort;</productname>
   <productnumber>&productnumber;</productnumber>
+  <meta name="title" its:translate="yes">&sap; Monitoring</meta>
+  <meta name="description" its:translate="yes">An introduction to monitoring solutions for &sap; administrators to efficiently monitor their &sap; systems.</meta>
+  <meta name="social-descr" its:translate="yes">Monitoring solutions for &sap; administrators.</meta>
   <date><?dbtimestamp format="B d, Y"?></date>
-  <meta name="task" its:translate="no">
+  <meta name="task" its:translate="yes">
     <phrase>Monitoring</phrase>
   </meta>
   <meta name="series" its:translate="no">Products &amp; Solutions</meta>


### PR DESCRIPTION
### Description

Add final metadata.

Based on multiple cherrypicks from 'main':

  * 7168c53d83fe1e9800b5b805d85252e56a616cea
  * 475fbeca4d6aaee1932e377798c8ce71aab181dc
  * 7b8f18148f3dd297b7b3c7d6485b1d56c2abdb50
  * cdb323874e75ef8224c6a8a1df447538473ca26a
  * ff8077508f06c04a11d21feb809821a48167d460
  * a8f7ab2b33f5f9bf49a280914e8e16a13e858037
  * 1b7d512ab5186fc15e0a1558456f5ca17a817cd1

(original PR: https://github.com/SUSE/doc-slesforsap/pull/176)

Revhistory needs to be backported in a separate commit, because the data differs from branch to branch. 

### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - SLES-SAP 12
  - [x] 12 SP5
  
### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
