### PR TITLE
SAP guide: integrate proofing corrections

### DIFF
--- a/xml/s4s_about.xml
+++ b/xml/s4s_about.xml
@@ -244,7 +244,7 @@
         The last service pack in each &slea; family does not have ESPOS. Instead
         of ESPOS, it includes a longer general support period. Because of that,
         LTSS is available only for the last service pack. All other service
-        packs already include three years of ESPOS, which equals LTSS.
+        packs already include three years of ESPOS, which is equal to LTSS.
      </para>
      <para>
       For more information, refer to the following resources:

--- a/xml/s4s_components.xml
+++ b/xml/s4s_components.xml
@@ -14,7 +14,7 @@
  </info>
  <para>
   As depicted in <xref linkend="fig-offering"/>, &sles4sap; is based on &sls;
-  but contains several additional software components such as &sleha;, and the
+  but contains several additional software components such as &sleha; and the
   installation workflow. These software components are briefly explained in the
   following sections.
  </para>


### PR DESCRIPTION
### Description

Integrate proofing corrections for the SAP Guide from proofing drop 3.

### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP6
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
 - SLES-SAP 12
  - [ ] 12 SP5 