### PR TITLE
Product renaming (SuMa -> SMLM)

### DIFF
--- a/xml/article_sap_automation.xml
+++ b/xml/article_sap_automation.xml
@@ -66,7 +66,7 @@ https://confluence.suse.com/x/8IEnGw
     <para>
       &suse; works in the overall project on additional parts that cover
       infrastructure aspects (like machines, network, disk formats, mount
-      points) that need to be performed with &suma;, &ay;, or Terraform
+      points) that need to be performed with &smlm;, &ay;, or Terraform
       and are not shipped as part of &productname;.
       These parts of the project available via &suse; GitHub repositories are
       published as-is and supported by the open source community. For more

--- a/xml/article_sap_monitoring.xml
+++ b/xml/article_sap_monitoring.xml
@@ -1761,7 +1761,7 @@ The exporter expects to find the <filename>sap_host_exporter.yaml</filename>, <f
    <listitem>
     <para>
      <link xlink:href="https://documentation.suse.com/suma/4.0/"
-            >&suma;</link>
+            >&smlm;</link>
     </para>
    </listitem>
    <listitem>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -22,7 +22,7 @@
 <!ENTITY docaddress     "<link xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='https://documentation.suse.com/sles-15'/>">
 <!ENTITY ha-docaddress  "<link xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='https://documentation.suse.com/sle-ha-15'/>">
 <!ENTITY sapnoteaddress "https://launchpad.support.sap.com/#/notes/">
-<!ENTITY suma-docaddress "<link xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='https://documentation.suse.com/suma'/>">
+<!ENTITY suma-docaddress "<link xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='https://documentation.suse.com/multi-linux-manager'/>">
 <!ENTITY reslibrary     "<link xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink' xlink:href='https://www.suse.com/products/sles-for-sap/resource-library/'/>">
 
 <!ENTITY rn-url "&sc-rn;/x86_64/SLE-SAP/15-SP7/">

--- a/xml/s4s_autoyast.xml
+++ b/xml/s4s_autoyast.xml
@@ -37,8 +37,8 @@
  </para>
 
  <para>
-   If you plan to deploy &sles4sap; from a &suma; server, refer to
-   <citetitle>&suma; <quote>Reference Manual</quote>, <quote>Systems</quote>, <quote>Autoinstallation</quote></citetitle> and <citetitle>&suma; <quote>Advanced Topics</quote>, Chapter <quote>Minimalist &ay; Profile for Automated Installations and Useful Enhancements</quote></citetitle> (&suma-docaddress;).
+   If you plan to deploy &sles4sap; from a &smlm; server, refer to
+   <citetitle>&smlm; <quote>&mgrrefguide;</quote>, <quote>Systems</quote>, <quote>Autoinstallation</quote></citetitle> and <citetitle>&suma; <quote>Advanced Topics</quote>, Chapter <quote>Minimalist &ay; Profile for Automated Installations and Useful Enhancements</quote></citetitle> (&suma-docaddress;).
  </para>
  
 </sect1>


### PR DESCRIPTION
### PR creator: Description

With the upcoming version 5.1, **SUSE Manager** will be renamed to **SUSE Multi-Linux Manager** (already released SuMa versions keep their name and their documentation URLs).

The SLE 15 SP7 documentation needs to reflect the product name change. 

Also, the 'generic' URL `https://documentation.suse.com/suma` (which always redirects to the docs for the latest released SuMa version) will be replaced with `https://documentation.suse.com/multi-linux-manager` moving forward.


### PR creator: Are there any relevant issues/feature requests?

https://jira.suse.com/browse/DOCTEAM-1754


### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [x] 15 next *(current `main`, no backport necessary)*
  
15 SP7 only - NO backports to older versions!