### PR TITLE
Remove no longer existing link

### DIFF
--- a/xml/article_sap_monitoring.xml
+++ b/xml/article_sap_monitoring.xml
@@ -1784,12 +1784,6 @@ The exporter expects to find the <filename>sap_host_exporter.yaml</filename>, <f
      helpful in isolated data centers without Internet connection.
     </para>
    </listitem>
-   <listitem>
-    <para>
-     <link xlink:href="https://techcommunity.microsoft.com/t5/running-sap-applications-on-the/suse-amp-microsoft-collaborates-to-provide-sap-monitoring/ba-p/1571926">&suse;
-     &amp; Microsoft collaborates to provide SAP monitoring</link>
-    </para>
-   </listitem>
   </itemizedlist>
  </sect1>
  <xi:include href="common_copyright_quick.xml"/>


### PR DESCRIPTION
### Description

Removing a  link to the article that no longer exists

### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [X] 15 SP7 *(current `main`, no backport necessary)*
  - [X] 15 SP6
  - [X] 15 SP5
  - [X] 15 SP4


