### PR TITLE
Update the name of the ISO images in the installation guide

### DIFF
--- a/xml/MAIN-SLES4SAP-guide.xml
+++ b/xml/MAIN-SLES4SAP-guide.xml
@@ -22,7 +22,7 @@
   <date><?dbtimestamp format="B d, Y"?></date>
   <revhistory xml:id="rh-book-s4s">
     <revision>
-      <date>2026-04-28</date>
+      <date>2026-07-09</date>
       <revdescription>
         <para/>
       </revdescription>
@@ -32,14 +32,6 @@
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.
-        </para>
-      </revdescription>
-    </revision>
-    <revision>
-      <date>2026-06-23</date>
-      <revdescription>
-        <para>
-          Fixing references in "Setting up an SAP HANA cluster".
         </para>
       </revdescription>
     </revision>

--- a/xml/s4s_installation.xml
+++ b/xml/s4s_installation.xml
@@ -14,7 +14,7 @@
   </dm:docmanager>
  <revhistory xml:id="rh-cha-install">
    <revision>
-     <date>2026-04-28</date>
+     <date>2026-07-09</date>
      <revdescription>
        <para/>
      </revdescription>
@@ -268,11 +268,9 @@
      </para>
      <para>
       To install a full (but not updated) &s4sa; system without network
-      access during the installation, use the &slea; &productnumber; Packages
+      access during the installation, use the &slea; &productnumber; Full Media 1
       ISO image from <link xlink:href="https://download.suse.com"/>. You can
-      then choose <guimenu>Skip registration</guimenu> on this page and
-      select the &slea; &productnumber; Packages ISO image as an add-on
-      product on the next page.
+      then choose <guimenu>Skip Registration</guimenu> on this page and register at a later date.
      </para>
     </important>
    </step>
@@ -389,15 +387,15 @@
      <listitem>
       <para>
        To install an &sap; Application along with the system,
-       activate <guimenu>Launch the SAP Installation Wizard right after the
+       activate <guimenu>Launch SAP product installation wizard right after the
        operating system is installed</guimenu>.
       </para>
      </listitem>
      <listitem>
       <para>
        To enable RDP access (Remote Desktop Protocol) to this machine,
-       activate <guimenu>Enable RDP service and open port in
-       firewall</guimenu>.
+       activate <guimenu>Enable Remote Desktop Protocol (RDP) Service and open port in
+       Firewall</guimenu>.
       </para>
       <para condition="noquick">
        For more information about connecting via RDP, see


### PR DESCRIPTION
### Description

Raised by a GH issue, I am updating the installation guide with the correct ISO image names

### Are there any relevant issues/feature requests?

* https://github.com/SUSE/doc-slesforsap/issues/181

### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLES-SAP 15
  - [x] 15 SP7 *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4

### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] all necessary backports are done
- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
